### PR TITLE
Fix index conversion from source to Spanner

### DIFF
--- a/spanner/ddl/ast.go
+++ b/spanner/ddl/ast.go
@@ -399,9 +399,9 @@ func (ci CreateIndex) PrintCreateIndex(ct CreateTable, c Config) string {
 	if ci.StoredColumnIds != nil {
 		storedColumns := []string{}
 		for _, colId := range ci.StoredColumnIds {
-			storedColumns = append(storedColumns, ct.ColDefs[colId].Name)
+			storedColumns = append(storedColumns, c.quote(ct.ColDefs[colId].Name))
 		}
-		storingClause = fmt.Sprintf(" %s (%s)", stored, strings.Join(ci.StoredColumnIds, ", "))
+		storingClause = fmt.Sprintf(" %s (%s)", stored, strings.Join(storedColumns, ", "))
 	}
 	return fmt.Sprintf("CREATE %sINDEX %s ON %s (%s)%s", unique, c.quote(ci.Name), c.quote(ct.Name), strings.Join(keys, ", "), storingClause)
 }

--- a/spanner/ddl/ast.go
+++ b/spanner/ddl/ast.go
@@ -399,11 +399,25 @@ func (ci CreateIndex) PrintCreateIndex(ct CreateTable, c Config) string {
 	if ci.StoredColumnIds != nil {
 		storedColumns := []string{}
 		for _, colId := range ci.StoredColumnIds {
-			storedColumns = append(storedColumns, c.quote(ct.ColDefs[colId].Name))
+			if (!isStoredColumnKeyPartOfPrimaryKey(ct, colId)) {
+				storedColumns = append(storedColumns, c.quote(ct.ColDefs[colId].Name))
+			}
 		}
 		storingClause = fmt.Sprintf(" %s (%s)", stored, strings.Join(storedColumns, ", "))
 	}
 	return fmt.Sprintf("CREATE %sINDEX %s ON %s (%s)%s", unique, c.quote(ci.Name), c.quote(ct.Name), strings.Join(keys, ", "), storingClause)
+}
+
+// Checks if the colId is part of the primary of a table
+// Used for detecting if a key needs to be skipped while creating the
+// storing clause.
+func isStoredColumnKeyPartOfPrimaryKey(ct CreateTable, colId string) bool {
+	for _, pkey := range ct.PrimaryKeys {
+		if colId == pkey.ColId {
+			return true
+		}
+	}
+	return false
 }
 
 // PrintForeignKeyAlterTable unparses the foreign keys using ALTER TABLE.


### PR DESCRIPTION
Fixes  - 

1. Bug in the `name to id` implementation which added the columnIds in the `STORING` clause instead of the names.
2. In Spanner, the `STORING` clause of an `INDEX` cannot contain columns which are part of the primary of the base table. The base table's keys are already part of the keys of the index's underlying table and hence should be omitted from the `STORING` clause. This is a database agnostic conversion.