### PR TITLE
Improve logging and audit metadata for dataproc migration mode

### DIFF
--- a/conversion/conversion.go
+++ b/conversion/conversion.go
@@ -256,6 +256,7 @@ func performSnapshotMigration(config writer.BatchWriterConfig, conv *internal.Co
 }
 
 func processDataWithDataproc(sourceProfile profiles.SourceProfile, targetProfile profiles.TargetProfile, conv *internal.Conv, infoSchema common.InfoSchema) error {
+	ctx := context.Background()
 
 	orderTableNamesByID := ddl.GetSortedTableIdsBySpName(conv.SpSchema)
 	numberOfTables := int64(len(orderTableNamesByID))
@@ -270,9 +271,9 @@ func processDataWithDataproc(sourceProfile profiles.SourceProfile, targetProfile
 	region_string := subnet[0:strings.Index(subnet, "/subnetworks")]
 	location := subnet[strings.LastIndex(region_string, "/")+1 : strings.LastIndex(subnet, "/subnetworks")]
 
-	batchClient, err := dproc.CreateDataprocBatchClient(location)
+	batchClient, err := dproc.CreateDataprocBatchClient(ctx, location)
 	if err != nil {
-		log.Fatalf("error creating the batch client: %s\n", err)
+		log.Fatalf("Error creating the batch client: %s\n", err)
 		return err
 	}
 	logger.Log.Debug(fmt.Sprint("Dataproc batch client created"))
@@ -280,7 +281,6 @@ func processDataWithDataproc(sourceProfile profiles.SourceProfile, targetProfile
 
 	progressCtr := 0
 	for _, spannerTableID := range orderTableNamesByID {
-
 		srcTable := conv.SrcSchema[spannerTableID].Name
 
 		srcSchema := conv.SrcSchema[spannerTableID]
@@ -292,10 +292,31 @@ func processDataWithDataproc(sourceProfile profiles.SourceProfile, targetProfile
 			return err
 		}
 
-		id, err := dproc.TriggerDataprocTemplate(batchClient, srcTable, srcSchema.Schema, strings.Join(primaryKeys, ","), dataprocRequestParams)
+		op, err := dproc.TriggerDataprocTemplate(ctx, batchClient, srcTable, srcSchema.Schema, strings.Join(primaryKeys, ","), dataprocRequestParams)
 		if err != nil {
+			logger.Log.Error(fmt.Sprintf("Failing to trigger Dataproc template for %s.%s", srcSchema.Schema, srcTable))
 			return err
 		}
+		meta, _ := op.Metadata()
+		batchName := meta.Batch
+		splittedBatchName := strings.Split(batchName, "/")
+		jobId := splittedBatchName[5]
+
+		jobUrl := fmt.Sprintf("https://console.cloud.google.com/dataproc/batches/%s/%s?project=%s", location, jobId, dataprocRequestParams.Project)
+		conv.Audit.DataprocMetadata.DataprocJobUrls = append(conv.Audit.DataprocMetadata.DataprocJobUrls, jobUrl)
+		conv.Audit.DataprocMetadata.DataprocJobIds = append(conv.Audit.DataprocMetadata.DataprocJobIds, jobId)
+		conv.Audit.DataprocMetadata.DataprocJobStatus = append(conv.Audit.DataprocMetadata.DataprocJobStatus, "RUNNING")
+		logger.Log.Info(fmt.Sprintf("Dataproc template triggered for %s.%s : %s", srcSchema.Schema, srcTable, jobUrl))
+
+		_, err = op.Wait(ctx)
+		if err != nil {
+			conv.Audit.DataprocMetadata.DataprocJobStatus[progressCtr] = "FAILED"
+			logger.Log.Error(fmt.Sprintf("Error completing the batch [%s]:\n %s\n", jobId, err.Error()))
+			logger.Log.Error(fmt.Sprintf("Failing data migration from Dataproc template for %s.%s, Check: %s for more details\n", srcSchema.Schema, srcTable, jobUrl))
+			return err
+		}
+		conv.Audit.DataprocMetadata.DataprocJobStatus[progressCtr] = "SUCCESS"
+
 		if conv.DataFlush != nil {
 			conv.DataFlush()
 		}
@@ -304,11 +325,6 @@ func processDataWithDataproc(sourceProfile profiles.SourceProfile, targetProfile
 			progressCtr++
 			conv.Audit.Progress.MaybeReport(int64(progressCtr))
 		}
-
-		//TODO: eenclona@ will remove hardcoded us-central1
-		url := fmt.Sprintf("https://console.cloud.google.com/dataproc/batches/us-central1/%s", id)
-		conv.Audit.DataprocMetadata.DataprocJobUrls = append(conv.Audit.DataprocMetadata.DataprocJobUrls, url)
-		conv.Audit.DataprocMetadata.DataprocJobIds = append(conv.Audit.DataprocMetadata.DataprocJobIds, id)
 	}
 
 	return nil

--- a/internal/convert.go
+++ b/internal/convert.go
@@ -194,8 +194,9 @@ type streamingStats struct {
 }
 
 type dataprocMetadata struct {
-	DataprocJobUrls []string
-	DataprocJobIds  []string
+	DataprocJobUrls   []string
+	DataprocJobIds    []string
+	DataprocJobStatus []string
 }
 
 // Stores information related to rules during schema conversion

--- a/internal/convert.go
+++ b/internal/convert.go
@@ -194,9 +194,10 @@ type streamingStats struct {
 }
 
 type dataprocMetadata struct {
-	DataprocJobUrls   []string
-	DataprocJobIds    []string
-	DataprocJobStatus []string
+	SrcTable          map[string]string // Maps spanner table id to source table name
+	DataprocJobIds    map[string]string // Maps spanner table id to related dataproc job id
+	DataprocJobUrls   map[string]string // Maps spanner table id to related dataproc job url
+	DataprocJobStatus map[string]string // Maps spanner table id to related dataproc job status
 }
 
 // Stores information related to rules during schema conversion

--- a/webv2/web.go
+++ b/webv2/web.go
@@ -368,7 +368,7 @@ func setSourceDBDetailsForDump(w http.ResponseWriter, r *http.Request) {
 func getSourceProfileConfig(w http.ResponseWriter, r *http.Request) {
 	sessionState := session.GetSessionState()
 	sourceProfileConfig := sessionState.SourceProfileConfig
-	if (sourceProfileConfig.ConfigType == "dataflow") {
+	if sourceProfileConfig.ConfigType == "dataflow" {
 		for _, dataShard := range sourceProfileConfig.ShardConfigurationDataflow.DataShards {
 			bucket, rootPath, err := profile.GetBucket(sessionState.GCPProjectID, sessionState.Region, dataShard.DstConnectionProfile.Name)
 			if err != nil {
@@ -1183,7 +1183,7 @@ func getReportFile(w http.ResponseWriter, r *http.Request) {
 	w.Write([]byte(reportAbsPath))
 }
 
-// generates a downloadable structured report and send it as a JSON response  
+// generates a downloadable structured report and send it as a JSON response
 func getDStructuredReport(w http.ResponseWriter, r *http.Request) {
 	sessionState := session.GetSessionState()
 	structuredReport := reports.GenerateStructuredReport(sessionState.Driver, sessionState.DbName, sessionState.Conv, nil, true, true)
@@ -2044,8 +2044,12 @@ func getDataprocJobs(w http.ResponseWriter, r *http.Request) {
 	sessionState := session.GetSessionState()
 
 	if len(sessionState.Conv.Audit.DataprocMetadata.DataprocJobUrls) > 0 {
-		dataprocJobs.DataprocJobUrls = sessionState.Conv.Audit.DataprocMetadata.DataprocJobUrls
-		dataprocJobs.DataprocJobIds = sessionState.Conv.Audit.DataprocMetadata.DataprocJobIds
+		for tableId := range sessionState.Conv.Audit.DataprocMetadata.DataprocJobIds {
+			dataprocJobs.SrcTable = append(dataprocJobs.SrcTable, sessionState.Conv.Audit.DataprocMetadata.SrcTable[tableId])
+			dataprocJobs.DataprocJobIds = append(dataprocJobs.DataprocJobUrls, sessionState.Conv.Audit.DataprocMetadata.DataprocJobIds[tableId])
+			dataprocJobs.DataprocJobUrls = append(dataprocJobs.DataprocJobUrls, sessionState.Conv.Audit.DataprocMetadata.DataprocJobUrls[tableId])
+			dataprocJobs.DataprocJobStatus = append(dataprocJobs.DataprocJobUrls, sessionState.Conv.Audit.DataprocMetadata.DataprocJobStatus[tableId])
+		}
 	}
 	w.WriteHeader(http.StatusOK)
 	json.NewEncoder(w).Encode(dataprocJobs)
@@ -2713,8 +2717,10 @@ type GeneratedResources struct {
 }
 
 type DataprocJobs struct {
-	DataprocJobUrls []string
-	DataprocJobIds  []string
+	SrcTable          []string
+	DataprocJobIds    []string
+	DataprocJobUrls   []string
+	DataprocJobStatus []string
 }
 
 func addTypeToList(convertedType string, spType string, issues []internal.SchemaIssue, l []typeIssue) []typeIssue {

--- a/webv2/web.go
+++ b/webv2/web.go
@@ -2046,9 +2046,9 @@ func getDataprocJobs(w http.ResponseWriter, r *http.Request) {
 	if len(sessionState.Conv.Audit.DataprocMetadata.DataprocJobUrls) > 0 {
 		for tableId := range sessionState.Conv.Audit.DataprocMetadata.DataprocJobIds {
 			dataprocJobs.SrcTable = append(dataprocJobs.SrcTable, sessionState.Conv.Audit.DataprocMetadata.SrcTable[tableId])
-			dataprocJobs.DataprocJobIds = append(dataprocJobs.DataprocJobUrls, sessionState.Conv.Audit.DataprocMetadata.DataprocJobIds[tableId])
+			dataprocJobs.DataprocJobIds = append(dataprocJobs.DataprocJobIds, sessionState.Conv.Audit.DataprocMetadata.DataprocJobIds[tableId])
 			dataprocJobs.DataprocJobUrls = append(dataprocJobs.DataprocJobUrls, sessionState.Conv.Audit.DataprocMetadata.DataprocJobUrls[tableId])
-			dataprocJobs.DataprocJobStatus = append(dataprocJobs.DataprocJobUrls, sessionState.Conv.Audit.DataprocMetadata.DataprocJobStatus[tableId])
+			dataprocJobs.DataprocJobStatus = append(dataprocJobs.DataprocJobStatus, sessionState.Conv.Audit.DataprocMetadata.DataprocJobStatus[tableId])
 		}
 	}
 	w.WriteHeader(http.StatusOK)


### PR DESCRIPTION
* Reuse same Context object for all dataproc jobs
* Move job waiting outside `TriggerDataprocTemplate()`
* Add logging/auditing for dataproc jobs right after triggering
* Add more context to log message
* Remove hardcoded `us-central1` from jobUrl
* Add project id param in dataproc job url
* Change `DataprocMetadata` from array to map with table id as key
* Add `SrcTable` and`DataprocJobStatus`  to audit metadata