### PR TITLE
feat(frontend): add postgres support for dataproc migration

### DIFF
--- a/ui/src/app/components/prepare-migration/prepare-migration.component.ts
+++ b/ui/src/app/components/prepare-migration/prepare-migration.component.ts
@@ -151,7 +151,7 @@ export class PrepareMigrationComponent implements OnInit {
         }
       ]
       if (
-        this.sourceDatabaseType == SourceDbNames.MySQL.toLowerCase()
+        this.sourceDatabaseType == SourceDbNames.MySQL.toLowerCase() || this.sourceDatabaseType == SourceDbNames.Postgres.toLowerCase()
       ) {
         this.migrationTypes.push(
           {
@@ -218,7 +218,7 @@ export class PrepareMigrationComponent implements OnInit {
           }
         ]
         if (
-          res.DatabaseType == SourceDbNames.MySQL.toLowerCase()
+          res.DatabaseType == SourceDbNames.MySQL.toLowerCase() || res.DatabaseType == SourceDbNames.Postgres.toLowerCase()
         ) {
           this.migrationTypes.push({
             name: 'Migration via Dataproc',


### PR DESCRIPTION
This PR includes ui changes to show dataproc migration mode dropdown for source: Postgres.

Modify source type checks to allow postgres source as well (along with MySQL) in prepare-migration component 
[`SourceDbNames.MySQL` || `SourceDbNames.Postgres`]