### PR TITLE
docs: Added docs for datastream and gcs tuning

### DIFF
--- a/docs/ui/prepare-migration/dataflow-tuning.md
+++ b/docs/ui/prepare-migration/dataflow-tuning.md
@@ -3,7 +3,7 @@ layout: default
 title: Tune Dataflow (Optional)
 parent: Prepare Migration Page
 grand_parent: SMT UI
-nav_order: 4
+nav_order: 6
 ---
 
 # Tune Dataflow (Optional)
@@ -27,7 +27,7 @@ Some use cases when the user would want to tweak the jobs are:
 
 {: .highlight }
 
-To configure dataflow, first specify the target database in the 'Configure Spanner Database' step. This enables the configure button for the remaining steps.
+To tune dataflow, first specify the target database in the 'Configure Spanner Database' step. This enables the configure button for the remaining steps.
 
 ![](https://services.google.com/fh/gumdrop/preview/misc/dataflow-form.png)
 

--- a/docs/ui/prepare-migration/datastream-tuning.md
+++ b/docs/ui/prepare-migration/datastream-tuning.md
@@ -1,0 +1,49 @@
+---
+layout: default
+title: Tune Datastream (Optional)
+parent: Prepare Migration Page
+grand_parent: SMT UI
+nav_order: 4
+---
+
+# Tune Datastream (Optional)
+{: .no_toc }
+
+In case of minimal downtime migration, the Datastream jobs launched by the Spanner Migration Tool can be **optionally** tuned. Tuning refers to tweaking the default parameters to run Datastream is a custom configuration.
+
+## Tuning use cases
+
+SMT by default launches datastream 50 backfill tasks and 5 cdc tasks.
+
+Some use cases when the user would want to tweak these:
+- Reduce load during backfill on source database
+- Support more table processing in parallel for change events
+
+
+{: .highlight }
+
+To tune datastream, first specify the target database in the 'Configure Spanner Database' step. This enables the configure button for the remaining steps.
+
+![](https://services.google.com/fh/gumdrop/preview/misc/datastream-tuning.png)
+
+<details open markdown="block">
+  <summary>
+    Table of contents
+  </summary>
+  {: .text-delta }
+1. TOC
+{:toc}
+</details>
+
+{: .highlight }
+
+SMT exposes the maxConcurrentBackfillTasks and maxConcurrentCdcTasks for tuning. Please reach out to us if you have a use-case that is not satisfied by the provided configurations.
+
+
+Increasing the number of tasks does not speedup the processing of individual tables. Since each task is dedicated to processing a single table, adding more tasks will not enhance the processing speed of a single table. Essentially, the number of tasks determines the maximum number of tables that can be processed simultaneously.
+
+### Max Concurrent Backfill Tasks
+Specify the maximum parallel tasks during backfill. You can use values from 1 to 50 (inclusive). The default value is 50.
+
+### Max Concurrent Cdc Tasks (Not available for Postgres source)
+Specify the maximum parallel tasks during CDC. You can use values from 1 to 50 (inclusive). The default value is 5.

--- a/docs/ui/prepare-migration/end-migration.md
+++ b/docs/ui/prepare-migration/end-migration.md
@@ -3,7 +3,7 @@ layout: default
 title: End Migration
 parent: Prepare Migration Page
 grand_parent: SMT UI
-nav_order: 6
+nav_order: 8
 ---
 
 # End migration

--- a/docs/ui/prepare-migration/gcs-tuning.md
+++ b/docs/ui/prepare-migration/gcs-tuning.md
@@ -1,0 +1,41 @@
+---
+layout: default
+title: Tune Cloud Storage (Optional)
+parent: Prepare Migration Page
+grand_parent: SMT UI
+nav_order: 5
+---
+
+# Tune Cloud Storage (Optional)
+{: .no_toc }
+
+In case of minimal downtime migration, the Datastream jobs launched by the Spanner Migration Tool write data to a destination path on Google Cloud Storage. This data is the staging data dumped by Datastream from the source database and read by the Dataflow pipeline while writing to Spanner. The destination bucket can be **optionally** tuned via SMT. Currently, the only supported tuning is enabling ttl on the data outputted by Datastream.
+
+## Tuning use cases
+
+SMT by default does not add any configuration on the destination GCS bucket. 
+With the help of tuning, one can enable:
+- Enable a delete lifecycle rule on the data directory to delete objects after a certain age.
+
+
+{: .highlight }
+
+To tune GCS, first specify the target database in the 'Configure Spanner Database' step. This enables the configure button for the remaining steps.
+
+![](https://services.google.com/fh/gumdrop/preview/misc/gcs-tuning.png)
+
+<details open markdown="block">
+  <summary>
+    Table of contents
+  </summary>
+  {: .text-delta }
+1. TOC
+{:toc}
+</details>
+
+### Set TTL
+Specify the TTL in days to enable automatic deletion of datastream output records. By default, TTL is disabled. When enabled, SMT establishes a delete lifecycle rule on the data directory, which stores datastream output records. This rule automatically deletes objects once they reach the specified TTL.
+
+{: .warning }
+
+Setting TTL improperly can lead to completeness issues during migration if the data is deleted by the lifecycle policy prematurely.

--- a/docs/ui/prepare-migration/monitor.md
+++ b/docs/ui/prepare-migration/monitor.md
@@ -3,7 +3,7 @@ layout: default
 title: Monitoring
 parent: Prepare Migration Page
 grand_parent: SMT UI
-nav_order: 5
+nav_order: 7
 ---
 
 # Monitoring


### PR DESCRIPTION
Added docs for datastream and gcs tuning

Preview: https://deep1998.github.io/harbourbridge/ui/prepare-migration/datastream-tuning.html