### PR TITLE
Streaming go sample test

### DIFF
--- a/streaming/streaming.go
+++ b/streaming/streaming.go
@@ -518,8 +518,8 @@ func LaunchStream(ctx context.Context, sourceProfile profiles.SourceProfile, dbL
 	prefix = utils.ConcatDirectoryPath(prefix, "data")
 
 	gcsDstCfg := &datastreampb.GcsDestinationConfig{
-		Path:           prefix,
-		FileFormat:     &datastreampb.GcsDestinationConfig_JsonFileFormat{},
+		Path:       prefix,
+		FileFormat: &datastreampb.GcsDestinationConfig_AvroFileFormat{},
 	}
 	srcCfg := &datastreampb.SourceConfig{
 		SourceConnectionProfile: fmt.Sprintf("%s/locations/%s/connectionProfiles/%s", projectNumberResource, datastreamCfg.SourceConnectionConfig.Location, datastreamCfg.SourceConnectionConfig.Name),

--- a/streaming/streaming.go
+++ b/streaming/streaming.go
@@ -520,7 +520,6 @@ func LaunchStream(ctx context.Context, sourceProfile profiles.SourceProfile, dbL
 	gcsDstCfg := &datastreampb.GcsDestinationConfig{
 		Path:           prefix,
 		FileFormat:     &datastreampb.GcsDestinationConfig_JsonFileFormat{},
-		FileRotationMb: 5,
 	}
 	srcCfg := &datastreampb.SourceConfig{
 		SourceConnectionProfile: fmt.Sprintf("%s/locations/%s/connectionProfiles/%s", projectNumberResource, datastreamCfg.SourceConnectionConfig.Location, datastreamCfg.SourceConnectionConfig.Name),

--- a/test_data/streamingcfg.json
+++ b/test_data/streamingcfg.json
@@ -1,0 +1,48 @@
+{
+    "datastreamCfg": {
+     "streamId": "",
+     "streamLocation": "us-central1",
+     "streamDisplayName": "",
+     "sourceConnectionConfig": {
+      "Name": "stalltestxx",
+      "Location": "us-central1"
+     },
+     "destinationConnectionConfig": {
+      "Name": "stalltestyy3",
+      "Location": "us-central1",
+      "Prefix": ""
+     },
+     "properties": "",
+     "maxConcurrentBackfillTasks": "",
+     "maxConcurrentCdcTasks": ""
+    },
+    "gcsCfg": {
+     "ttlInDays": 0,
+     "ttlInDaysSet": false
+    },
+    "dataflowCfg": {
+     "projectId": "",
+     "jobName": "",
+     "location": "us-central1",
+     "hostProjectId": "",
+     "network": "",
+     "subnetwork": "",
+     "maxWorkers": "",
+     "numWorkers": "",
+     "serviceAccountEmail": "",
+     "machineType": "",
+     "additionalUserLabels": "",
+     "kmsKeyName": "",
+     "gcsTemplatePath": "",
+     "dbNameToShardIdMap": null
+    },
+    "tmpDir": "gs://smt-job-6a99-2bcc/",
+    "pubsubCfg": {
+     "TopicId": "",
+     "SubscriptionId": "",
+     "NotificationId": "",
+     "BucketName": "",
+     "Region": ""
+    },
+    "dataShardId": ""
+   }


### PR DESCRIPTION
- Provides a sample test for streaming go with minimally invasive changes to test the `LaunchDataflowJob` function.
- It does not refactor the whole file, just adds a unit test for the specified public method.
- It mocks out the Dataflow and Datastream client external API calls.
- It can be said with a high degree of confidence that these changes are not breaking and most likely will not cause a regression.