### PR TITLE
[feat] RR Create API 2: Add storage and spanner accessor 

### DIFF
--- a/accessors/clients/dataflow/dataflow_client.go
+++ b/accessors/clients/dataflow/dataflow_client.go
@@ -19,13 +19,7 @@ import (
 	"sync"
 
 	dataflow "cloud.google.com/go/dataflow/apiv1beta3"
-	"cloud.google.com/go/dataflow/apiv1beta3/dataflowpb"
-	"github.com/googleapis/gax-go/v2"
 )
-
-type DataflowClient interface {
-	LaunchFlexTemplate(ctx context.Context, req *dataflowpb.LaunchFlexTemplateRequest, opts ...gax.CallOption) (*dataflowpb.LaunchFlexTemplateResponse, error)
-}
 
 var once sync.Once
 var dfClient *dataflow.FlexTemplatesClient

--- a/accessors/clients/dataflow/dataflow_client.go
+++ b/accessors/clients/dataflow/dataflow_client.go
@@ -25,7 +25,7 @@ var once sync.Once
 var dfClient *dataflow.FlexTemplatesClient
 
 // This function is declared as a global variable to make it testable. The unit
-// tests edit this function, acting like a double.
+// tests update this function, acting like a double.
 var newFlexTemplatesClient = dataflow.NewFlexTemplatesClient
 
 func GetOrCreateClient(ctx context.Context) (*dataflow.FlexTemplatesClient, error) {

--- a/accessors/clients/dataflow/interface.go
+++ b/accessors/clients/dataflow/interface.go
@@ -21,10 +21,12 @@ import (
 	"github.com/googleapis/gax-go/v2"
 )
 
+// Use this interface instead of dataflow.FlexTemplatesClient to support mocking.
 type DataflowClient interface {
 	LaunchFlexTemplate(ctx context.Context, req *dataflowpb.LaunchFlexTemplateRequest, opts ...gax.CallOption) (*dataflowpb.LaunchFlexTemplateResponse, error)
 }
 
+// This implements the DataflowClient interface. This is the primary implementation that should be used in all places other than tests.
 type DataflowClientImpl struct {
 	client *dataflow.FlexTemplatesClient
 }

--- a/accessors/clients/dataflow/interface.go
+++ b/accessors/clients/dataflow/interface.go
@@ -1,0 +1,42 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package dataflowclient
+
+import (
+	"context"
+
+	dataflow "cloud.google.com/go/dataflow/apiv1beta3"
+	"cloud.google.com/go/dataflow/apiv1beta3/dataflowpb"
+	"github.com/googleapis/gax-go/v2"
+)
+
+type DataflowClient interface {
+	LaunchFlexTemplate(ctx context.Context, req *dataflowpb.LaunchFlexTemplateRequest, opts ...gax.CallOption) (*dataflowpb.LaunchFlexTemplateResponse, error)
+}
+
+type DataflowClientImpl struct {
+	client *dataflow.FlexTemplatesClient
+}
+
+func NewDataflowClientImpl(ctx context.Context) (*DataflowClientImpl, error) {
+	c, err := GetOrCreateClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return &DataflowClientImpl{client: c}, nil
+}
+
+func (c *DataflowClientImpl) LaunchFlexTemplate(ctx context.Context, req *dataflowpb.LaunchFlexTemplateRequest, opts ...gax.CallOption) (*dataflowpb.LaunchFlexTemplateResponse, error) {
+	return c.client.LaunchFlexTemplate(ctx, req, opts...)
+}

--- a/accessors/clients/dataflow/mocks.go
+++ b/accessors/clients/dataflow/mocks.go
@@ -20,6 +20,8 @@ import (
 	"github.com/googleapis/gax-go/v2"
 )
 
+// Mock that implements the DataflowClient interface.
+// Pass in unit tests where DataflowClient is an input parameter.
 type DataflowClientMock struct {
 	LaunchFlexTemplateMock func(ctx context.Context, req *dataflowpb.LaunchFlexTemplateRequest, opts ...gax.CallOption) (*dataflowpb.LaunchFlexTemplateResponse, error)
 }

--- a/accessors/clients/dataflow/mocks.go
+++ b/accessors/clients/dataflow/mocks.go
@@ -11,33 +11,19 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-package storageclient
+package dataflowclient
 
 import (
 	"context"
-	"fmt"
-	"sync"
 
-	"cloud.google.com/go/storage"
+	"cloud.google.com/go/dataflow/apiv1beta3/dataflowpb"
+	"github.com/googleapis/gax-go/v2"
 )
 
-var once sync.Once
-var gcsClient *storage.Client
+type DataflowClientMock struct {
+	LaunchFlexTemplateMock func(ctx context.Context, req *dataflowpb.LaunchFlexTemplateRequest, opts ...gax.CallOption) (*dataflowpb.LaunchFlexTemplateResponse, error)
+}
 
-// This function is declared as a global variable to make it testable. The unit
-// tests edit this function, acting like a double.
-var newClient = storage.NewClient
-
-func GetOrCreateClient(ctx context.Context) (*storage.Client, error) {
-	var err error
-	if gcsClient == nil {
-		once.Do(func() {
-			gcsClient, err = newClient(ctx)
-		})
-		if err != nil {
-			return nil, fmt.Errorf("failed to create storage client: %v", err)
-		}
-		return gcsClient, nil
-	}
-	return gcsClient, nil
+func (dcm *DataflowClientMock) LaunchFlexTemplate(ctx context.Context, req *dataflowpb.LaunchFlexTemplateRequest, opts ...gax.CallOption) (*dataflowpb.LaunchFlexTemplateResponse, error) {
+	return dcm.LaunchFlexTemplateMock(ctx, req, opts...)
 }

--- a/accessors/clients/spanner/admin/admin_client.go
+++ b/accessors/clients/spanner/admin/admin_client.go
@@ -19,8 +19,6 @@ import (
 	"sync"
 
 	database "cloud.google.com/go/spanner/admin/database/apiv1"
-	"cloud.google.com/go/spanner/admin/database/apiv1/databasepb"
-	"github.com/googleapis/gax-go/v2"
 )
 
 var once sync.Once
@@ -42,66 +40,4 @@ func GetOrCreateClient(ctx context.Context) (*database.DatabaseAdminClient, erro
 		return spannerAdminClient, nil
 	}
 	return spannerAdminClient, nil
-}
-
-type AdminClient interface {
-	GetDatabase(ctx context.Context, req *databasepb.GetDatabaseRequest, opts ...gax.CallOption) (*databasepb.Database, error)
-	CreateDatabase(ctx context.Context, req *databasepb.CreateDatabaseRequest, opts ...gax.CallOption) (CreateDatabaseOperation, error)
-	UpdateDatabaseDdl(ctx context.Context, req *databasepb.UpdateDatabaseDdlRequest, opts ...gax.CallOption) (UpdateDatabaseDdlOperation, error)
-}
-
-type CreateDatabaseOperation interface {
-	Wait(ctx context.Context, opts ...gax.CallOption) (*databasepb.Database, error)
-}
-
-type UpdateDatabaseDdlOperation interface {
-	Wait(ctx context.Context, opts ...gax.CallOption) error
-}
-
-type AdminClientImpl struct {
-	adminClient *database.DatabaseAdminClient
-}
-
-func NewAdminClientImpl(ctx context.Context) (*AdminClientImpl, error) {
-	c, err := GetOrCreateClient(ctx)
-	if err != nil {
-		return nil, err
-	}
-	return &AdminClientImpl{adminClient: c}, nil
-}
-
-func (c *AdminClientImpl) GetDatabase(ctx context.Context, req *databasepb.GetDatabaseRequest, opts ...gax.CallOption) (*databasepb.Database, error) {
-	return c.adminClient.GetDatabase(ctx, req, opts...)
-}
-
-func (c *AdminClientImpl) CreateDatabase(ctx context.Context, req *databasepb.CreateDatabaseRequest, opts ...gax.CallOption) (CreateDatabaseOperation, error) {
-	op, err := c.adminClient.CreateDatabase(ctx, req, opts...)
-	if err != nil {
-		return nil, err
-	}
-	return &CreateDatabaseOperationImpl{dbo: op}, nil
-}
-
-func (c *AdminClientImpl) UpdateDatabaseDdl(ctx context.Context, req *databasepb.UpdateDatabaseDdlRequest, opts ...gax.CallOption) (UpdateDatabaseDdlOperation, error) {
-	op, err := c.adminClient.UpdateDatabaseDdl(ctx, req, opts...)
-	if err != nil {
-		return nil, err
-	}
-	return &UpdateDatabaseDdlImpl{dbo: op}, nil
-}
-
-type CreateDatabaseOperationImpl struct {
-	dbo *database.CreateDatabaseOperation
-}
-
-func (c *CreateDatabaseOperationImpl) Wait(ctx context.Context, opts ...gax.CallOption) (*databasepb.Database, error) {
-	return c.dbo.Wait(ctx, opts...)
-}
-
-type UpdateDatabaseDdlImpl struct {
-	dbo *database.UpdateDatabaseDdlOperation
-}
-
-func (c *UpdateDatabaseDdlImpl) Wait(ctx context.Context, opts ...gax.CallOption) error {
-	return c.dbo.Wait(ctx, opts...)
 }

--- a/accessors/clients/spanner/admin/admin_client.go
+++ b/accessors/clients/spanner/admin/admin_client.go
@@ -25,7 +25,7 @@ var once sync.Once
 var spannerAdminClient *database.DatabaseAdminClient
 
 // This function is declared as a global variable to make it testable. The unit
-// tests edit this function, acting like a double.
+// tests update this function, acting like a double.
 var newDatabaseAdminClient = database.NewDatabaseAdminClient
 
 func GetOrCreateClient(ctx context.Context) (*database.DatabaseAdminClient, error) {

--- a/accessors/clients/spanner/admin/admin_client.go
+++ b/accessors/clients/spanner/admin/admin_client.go
@@ -1,0 +1,39 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package spanneradmin
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	database "cloud.google.com/go/spanner/admin/database/apiv1"
+)
+
+var once sync.Once
+var spannerAdminClient *database.DatabaseAdminClient
+
+func GetOrCreateClient(ctx context.Context) (*database.DatabaseAdminClient, error) {
+	var err error
+	if spannerAdminClient == nil {
+		once.Do(func() {
+			spannerAdminClient, err = database.NewDatabaseAdminClient(ctx)
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to create spanner admin client: %v", err)
+		}
+		return spannerAdminClient, nil
+	}
+	return spannerAdminClient, nil
+}

--- a/accessors/clients/spanner/admin/admin_client.go
+++ b/accessors/clients/spanner/admin/admin_client.go
@@ -24,11 +24,15 @@ import (
 var once sync.Once
 var spannerAdminClient *database.DatabaseAdminClient
 
+// This function is declared as a global variable to make it testable. The unit
+// tests edit this function, acting like a double.
+var newDatabaseAdminClient = database.NewDatabaseAdminClient
+
 func GetOrCreateClient(ctx context.Context) (*database.DatabaseAdminClient, error) {
 	var err error
 	if spannerAdminClient == nil {
 		once.Do(func() {
-			spannerAdminClient, err = database.NewDatabaseAdminClient(ctx)
+			spannerAdminClient, err = newDatabaseAdminClient(ctx)
 		})
 		if err != nil {
 			return nil, fmt.Errorf("failed to create spanner admin client: %v", err)

--- a/accessors/clients/spanner/admin/admin_client_test.go
+++ b/accessors/clients/spanner/admin/admin_client_test.go
@@ -1,0 +1,14 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package spanneradmin

--- a/accessors/clients/spanner/admin/admin_client_test.go
+++ b/accessors/clients/spanner/admin/admin_client_test.go
@@ -12,3 +12,105 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 package spanneradmin
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sync"
+	"testing"
+
+	database "cloud.google.com/go/spanner/admin/database/apiv1"
+	"github.com/GoogleCloudPlatform/spanner-migration-tool/logger"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+	"google.golang.org/api/option"
+)
+
+func init() {
+	logger.Log = zap.NewNop()
+}
+
+func TestMain(m *testing.M) {
+	res := m.Run()
+	os.Exit(res)
+}
+
+func resetTest() {
+	spannerAdminClient = nil
+	once = sync.Once{}
+}
+
+func TestGetOrCreateClient_Basic(t *testing.T) {
+	resetTest()
+	ctx := context.Background()
+	oldFunc := newDatabaseAdminClient
+	defer func() { newDatabaseAdminClient = oldFunc }()
+	newDatabaseAdminClient = func(ctx context.Context, opts ...option.ClientOption) (*database.DatabaseAdminClient, error) {
+		return &database.DatabaseAdminClient{}, nil
+	}
+	c, err := GetOrCreateClient(ctx)
+	assert.NotNil(t, c)
+	assert.Nil(t, err)
+}
+
+func TestGetOrCreateClient_OnlyOnceViaSync(t *testing.T) {
+	resetTest()
+	ctx := context.Background()
+	oldFunc := newDatabaseAdminClient
+	defer func() { newDatabaseAdminClient = oldFunc }()
+
+	newDatabaseAdminClient = func(ctx context.Context, opts ...option.ClientOption) (*database.DatabaseAdminClient, error) {
+		return &database.DatabaseAdminClient{}, nil
+	}
+	c, err := GetOrCreateClient(ctx)
+	assert.NotNil(t, c)
+	assert.Nil(t, err)
+	// Explicitly set the client to nil. Running GetOrCreateClient should not create a
+	// new client since sync would already be executed.
+	spannerAdminClient = nil
+	newDatabaseAdminClient = func(ctx context.Context, opts ...option.ClientOption) (*database.DatabaseAdminClient, error) {
+		return nil, fmt.Errorf("test error")
+	}
+	c, err = GetOrCreateClient(ctx)
+	assert.Nil(t, c)
+	assert.Nil(t, err)
+}
+
+func TestGetOrCreateClient_OnlyOnceViaIf(t *testing.T) {
+	resetTest()
+	ctx := context.Background()
+	oldFunc := newDatabaseAdminClient
+	defer func() { newDatabaseAdminClient = oldFunc }()
+
+	newDatabaseAdminClient = func(ctx context.Context, opts ...option.ClientOption) (*database.DatabaseAdminClient, error) {
+		return &database.DatabaseAdminClient{}, nil
+	}
+	oldC, err := GetOrCreateClient(ctx)
+	assert.NotNil(t, oldC)
+	assert.Nil(t, err)
+
+	// Explicitly reset once. Running GetOrCreateClient should not create a
+	// new client the if condition should prevent it.
+	once = sync.Once{}
+	newDatabaseAdminClient = func(ctx context.Context, opts ...option.ClientOption) (*database.DatabaseAdminClient, error) {
+		return nil, fmt.Errorf("test error")
+	}
+	newC, err := GetOrCreateClient(ctx)
+	assert.Equal(t, oldC, newC)
+	assert.Nil(t, err)
+}
+
+func TestGetOrCreateClient_Error(t *testing.T) {
+	resetTest()
+	ctx := context.Background()
+	oldFunc := newDatabaseAdminClient
+	defer func() { newDatabaseAdminClient = oldFunc }()
+
+	newDatabaseAdminClient = func(ctx context.Context, opts ...option.ClientOption) (*database.DatabaseAdminClient, error) {
+		return nil, fmt.Errorf("test error")
+	}
+	c, err := GetOrCreateClient(ctx)
+	assert.Nil(t, c)
+	assert.NotNil(t, err)
+}

--- a/accessors/clients/spanner/admin/interface.go
+++ b/accessors/clients/spanner/admin/interface.go
@@ -21,20 +21,24 @@ import (
 	"github.com/googleapis/gax-go/v2"
 )
 
+// Use this interface instead of database.DatabaseAdminClient to support mocking.
 type AdminClient interface {
 	GetDatabase(ctx context.Context, req *databasepb.GetDatabaseRequest, opts ...gax.CallOption) (*databasepb.Database, error)
 	CreateDatabase(ctx context.Context, req *databasepb.CreateDatabaseRequest, opts ...gax.CallOption) (CreateDatabaseOperation, error)
 	UpdateDatabaseDdl(ctx context.Context, req *databasepb.UpdateDatabaseDdlRequest, opts ...gax.CallOption) (UpdateDatabaseDdlOperation, error)
 }
 
+// Use this interface instead of database.CreateDatabaseOperation to support mocking.
 type CreateDatabaseOperation interface {
 	Wait(ctx context.Context, opts ...gax.CallOption) (*databasepb.Database, error)
 }
 
+// Use this interface instead of database.UpdateDatabaseDdlOperation to support mocking.
 type UpdateDatabaseDdlOperation interface {
 	Wait(ctx context.Context, opts ...gax.CallOption) error
 }
 
+// This implements the AdminClient interface. This is the primary implementation that should be used in all places other than tests.
 type AdminClientImpl struct {
 	adminClient *database.DatabaseAdminClient
 }
@@ -67,6 +71,7 @@ func (c *AdminClientImpl) UpdateDatabaseDdl(ctx context.Context, req *databasepb
 	return &UpdateDatabaseDdlImpl{dbo: op}, nil
 }
 
+// This implements the CreateDatabaseOperation interface. This is the primary implementation that should be used in all places other than tests.
 type CreateDatabaseOperationImpl struct {
 	dbo *database.CreateDatabaseOperation
 }
@@ -75,6 +80,7 @@ func (c *CreateDatabaseOperationImpl) Wait(ctx context.Context, opts ...gax.Call
 	return c.dbo.Wait(ctx, opts...)
 }
 
+// This implements the UpdateDatabaseDdl interface. This is the primary implementation that should be used in all places other than tests.
 type UpdateDatabaseDdlImpl struct {
 	dbo *database.UpdateDatabaseDdlOperation
 }

--- a/accessors/clients/spanner/admin/interface.go
+++ b/accessors/clients/spanner/admin/interface.go
@@ -1,0 +1,84 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package spanneradmin
+
+import (
+	"context"
+
+	database "cloud.google.com/go/spanner/admin/database/apiv1"
+	"cloud.google.com/go/spanner/admin/database/apiv1/databasepb"
+	"github.com/googleapis/gax-go/v2"
+)
+
+type AdminClient interface {
+	GetDatabase(ctx context.Context, req *databasepb.GetDatabaseRequest, opts ...gax.CallOption) (*databasepb.Database, error)
+	CreateDatabase(ctx context.Context, req *databasepb.CreateDatabaseRequest, opts ...gax.CallOption) (CreateDatabaseOperation, error)
+	UpdateDatabaseDdl(ctx context.Context, req *databasepb.UpdateDatabaseDdlRequest, opts ...gax.CallOption) (UpdateDatabaseDdlOperation, error)
+}
+
+type CreateDatabaseOperation interface {
+	Wait(ctx context.Context, opts ...gax.CallOption) (*databasepb.Database, error)
+}
+
+type UpdateDatabaseDdlOperation interface {
+	Wait(ctx context.Context, opts ...gax.CallOption) error
+}
+
+type AdminClientImpl struct {
+	adminClient *database.DatabaseAdminClient
+}
+
+func NewAdminClientImpl(ctx context.Context) (*AdminClientImpl, error) {
+	c, err := GetOrCreateClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return &AdminClientImpl{adminClient: c}, nil
+}
+
+func (c *AdminClientImpl) GetDatabase(ctx context.Context, req *databasepb.GetDatabaseRequest, opts ...gax.CallOption) (*databasepb.Database, error) {
+	return c.adminClient.GetDatabase(ctx, req, opts...)
+}
+
+func (c *AdminClientImpl) CreateDatabase(ctx context.Context, req *databasepb.CreateDatabaseRequest, opts ...gax.CallOption) (CreateDatabaseOperation, error) {
+	op, err := c.adminClient.CreateDatabase(ctx, req, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return &CreateDatabaseOperationImpl{dbo: op}, nil
+}
+
+func (c *AdminClientImpl) UpdateDatabaseDdl(ctx context.Context, req *databasepb.UpdateDatabaseDdlRequest, opts ...gax.CallOption) (UpdateDatabaseDdlOperation, error) {
+	op, err := c.adminClient.UpdateDatabaseDdl(ctx, req, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return &UpdateDatabaseDdlImpl{dbo: op}, nil
+}
+
+type CreateDatabaseOperationImpl struct {
+	dbo *database.CreateDatabaseOperation
+}
+
+func (c *CreateDatabaseOperationImpl) Wait(ctx context.Context, opts ...gax.CallOption) (*databasepb.Database, error) {
+	return c.dbo.Wait(ctx, opts...)
+}
+
+type UpdateDatabaseDdlImpl struct {
+	dbo *database.UpdateDatabaseDdlOperation
+}
+
+func (c *UpdateDatabaseDdlImpl) Wait(ctx context.Context, opts ...gax.CallOption) error {
+	return c.dbo.Wait(ctx, opts...)
+}

--- a/accessors/clients/spanner/admin/mocks.go
+++ b/accessors/clients/spanner/admin/mocks.go
@@ -20,6 +20,8 @@ import (
 	"github.com/googleapis/gax-go/v2"
 )
 
+// Mock that implements the AdminClient interface.
+// Pass in unit tests where AdminClient is an input parameter.
 type AdminClientMock struct {
 	GetDatabaseMock       func(ctx context.Context, req *databasepb.GetDatabaseRequest, opts ...gax.CallOption) (*databasepb.Database, error)
 	CreateDatabaseMock    func(ctx context.Context, req *databasepb.CreateDatabaseRequest, opts ...gax.CallOption) (CreateDatabaseOperation, error)
@@ -38,6 +40,8 @@ func (acm *AdminClientMock) UpdateDatabaseDdl(ctx context.Context, req *database
 	return acm.UpdateDatabaseDdlMock(ctx, req, opts...)
 }
 
+// Mock that implements the CreateDatabaseOperation interface.
+// Pass in unit tests where CreateDatabaseOperation is an input parameter.
 type CreateDatabaseOperationMock struct {
 	WaitMock func(ctx context.Context, opts ...gax.CallOption) (*databasepb.Database, error)
 }
@@ -46,6 +50,8 @@ func (dbo *CreateDatabaseOperationMock) Wait(ctx context.Context, opts ...gax.Ca
 	return dbo.WaitMock(ctx, opts...)
 }
 
+// Mock that implements the UpdateDatabaseDdlOperation interface.
+// Pass in unit tests where UpdateDatabaseDdlOperation is an input parameter.
 type UpdateDatabaseDdlOperationMock struct {
 	WaitMock func(ctx context.Context, opts ...gax.CallOption) error
 }

--- a/accessors/clients/spanner/admin/mocks.go
+++ b/accessors/clients/spanner/admin/mocks.go
@@ -12,3 +12,44 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 package spanneradmin
+
+import (
+	"context"
+
+	"cloud.google.com/go/spanner/admin/database/apiv1/databasepb"
+	"github.com/googleapis/gax-go/v2"
+)
+
+type AdminClientMock struct {
+	GetDatabaseMock       func(ctx context.Context, req *databasepb.GetDatabaseRequest, opts ...gax.CallOption) (*databasepb.Database, error)
+	CreateDatabaseMock    func(ctx context.Context, req *databasepb.CreateDatabaseRequest, opts ...gax.CallOption) (CreateDatabaseOperation, error)
+	UpdateDatabaseDdlMock func(ctx context.Context, req *databasepb.UpdateDatabaseDdlRequest, opts ...gax.CallOption) (UpdateDatabaseDdlOperation, error)
+}
+
+func (acm *AdminClientMock) GetDatabase(ctx context.Context, req *databasepb.GetDatabaseRequest, opts ...gax.CallOption) (*databasepb.Database, error) {
+	return acm.GetDatabaseMock(ctx, req, opts...)
+}
+
+func (acm *AdminClientMock) CreateDatabase(ctx context.Context, req *databasepb.CreateDatabaseRequest, opts ...gax.CallOption) (CreateDatabaseOperation, error) {
+	return acm.CreateDatabaseMock(ctx, req, opts...)
+}
+
+func (acm *AdminClientMock) UpdateDatabaseDdl(ctx context.Context, req *databasepb.UpdateDatabaseDdlRequest, opts ...gax.CallOption) (UpdateDatabaseDdlOperation, error) {
+	return acm.UpdateDatabaseDdlMock(ctx, req, opts...)
+}
+
+type CreateDatabaseOperationMock struct {
+	WaitMock func(ctx context.Context, opts ...gax.CallOption) (*databasepb.Database, error)
+}
+
+func (dbo *CreateDatabaseOperationMock) Wait(ctx context.Context, opts ...gax.CallOption) (*databasepb.Database, error) {
+	return dbo.WaitMock(ctx, opts...)
+}
+
+type UpdateDatabaseDdlOperationMock struct {
+	WaitMock func(ctx context.Context, opts ...gax.CallOption) error
+}
+
+func (dbo *UpdateDatabaseDdlOperationMock) Wait(ctx context.Context, opts ...gax.CallOption) error {
+	return dbo.WaitMock(ctx, opts...)
+}

--- a/accessors/clients/spanner/admin/mocks.go
+++ b/accessors/clients/spanner/admin/mocks.go
@@ -1,0 +1,14 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package spanneradmin

--- a/accessors/clients/spanner/client/spanner_client.go
+++ b/accessors/clients/spanner/client/spanner_client.go
@@ -24,11 +24,15 @@ import (
 var once sync.Once
 var spannerClient *sp.Client
 
+// This function is declared as a global variable to make it testable. The unit
+// tests edit this function, acting like a double.
+var newClient = sp.NewClient
+
 func GetOrCreateClient(ctx context.Context, dbURI string) (*sp.Client, error) {
 	var err error
-	if spannerClient == nil || spannerClient.DatabaseName() != dbURI {
+	if spannerClient == nil {
 		once.Do(func() {
-			spannerClient, err = sp.NewClient(ctx, dbURI)
+			spannerClient, err = newClient(ctx, dbURI)
 		})
 		if err != nil {
 			return nil, fmt.Errorf("failed to create spanner database client: %v", err)

--- a/accessors/clients/spanner/client/spanner_client.go
+++ b/accessors/clients/spanner/client/spanner_client.go
@@ -1,0 +1,39 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package spannerclient
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	sp "cloud.google.com/go/spanner"
+)
+
+var once sync.Once
+var spannerClient *sp.Client
+
+func GetOrCreateClient(ctx context.Context, dbURI string) (*sp.Client, error) {
+	var err error
+	if spannerClient == nil || spannerClient.DatabaseName() != dbURI {
+		once.Do(func() {
+			spannerClient, err = sp.NewClient(ctx, dbURI)
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to create spanner database client: %v", err)
+		}
+		return spannerClient, nil
+	}
+	return spannerClient, nil
+}

--- a/accessors/clients/spanner/client/spanner_client_test.go
+++ b/accessors/clients/spanner/client/spanner_client_test.go
@@ -1,0 +1,14 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package spannerclient

--- a/accessors/clients/spanner/client/spanner_client_test.go
+++ b/accessors/clients/spanner/client/spanner_client_test.go
@@ -12,3 +12,105 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 package spannerclient
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sync"
+	"testing"
+
+	sp "cloud.google.com/go/spanner"
+	"github.com/GoogleCloudPlatform/spanner-migration-tool/logger"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+	"google.golang.org/api/option"
+)
+
+func init() {
+	logger.Log = zap.NewNop()
+}
+
+func TestMain(m *testing.M) {
+	res := m.Run()
+	os.Exit(res)
+}
+
+func resetTest() {
+	spannerClient = nil
+	once = sync.Once{}
+}
+
+func TestGetOrCreateClient_Basic(t *testing.T) {
+	resetTest()
+	ctx := context.Background()
+	oldFunc := newClient
+	defer func() { newClient = oldFunc }()
+	newClient = func(ctx context.Context, database string, opts ...option.ClientOption) (*sp.Client, error) {
+		return &sp.Client{}, nil
+	}
+	c, err := GetOrCreateClient(ctx, "testURI")
+	assert.NotNil(t, c)
+	assert.Nil(t, err)
+}
+
+func TestGetOrCreateClient_OnlyOnceViaSync(t *testing.T) {
+	resetTest()
+	ctx := context.Background()
+	oldFunc := newClient
+	defer func() { newClient = oldFunc }()
+
+	newClient = func(ctx context.Context, database string, opts ...option.ClientOption) (*sp.Client, error) {
+		return &sp.Client{}, nil
+	}
+	c, err := GetOrCreateClient(ctx, "testURI")
+	assert.NotNil(t, c)
+	assert.Nil(t, err)
+	// Explicitly set the client to nil. Running GetOrCreateClient should not create a
+	// new client since sync would already be executed.
+	spannerClient = nil
+	newClient = func(ctx context.Context, database string, opts ...option.ClientOption) (*sp.Client, error) {
+		return nil, fmt.Errorf("test error")
+	}
+	c, err = GetOrCreateClient(ctx, "testURI")
+	assert.Nil(t, c)
+	assert.Nil(t, err)
+}
+
+func TestGetOrCreateClient_OnlyOnceViaIf(t *testing.T) {
+	resetTest()
+	ctx := context.Background()
+	oldFunc := newClient
+	defer func() { newClient = oldFunc }()
+
+	newClient = func(ctx context.Context, database string, opts ...option.ClientOption) (*sp.Client, error) {
+		return &sp.Client{}, nil
+	}
+	oldC, err := GetOrCreateClient(ctx, "testURI")
+	assert.NotNil(t, oldC)
+	assert.Nil(t, err)
+
+	// Explicitly reset once. Running GetOrCreateClient should not create a
+	// new client the if condition should prevent it.
+	once = sync.Once{}
+	newClient = func(ctx context.Context, database string, opts ...option.ClientOption) (*sp.Client, error) {
+		return nil, fmt.Errorf("test error")
+	}
+	newC, err := GetOrCreateClient(ctx, "testURI")
+	assert.Equal(t, oldC, newC)
+	assert.Nil(t, err)
+}
+
+func TestGetOrCreateClient_Error(t *testing.T) {
+	resetTest()
+	ctx := context.Background()
+	oldFunc := newClient
+	defer func() { newClient = oldFunc }()
+
+	newClient = func(ctx context.Context, database string, opts ...option.ClientOption) (*sp.Client, error) {
+		return nil, fmt.Errorf("test error")
+	}
+	c, err := GetOrCreateClient(ctx, "testURI")
+	assert.Nil(t, c)
+	assert.NotNil(t, err)
+}

--- a/accessors/clients/spanner/instanceadmin/interface.go
+++ b/accessors/clients/spanner/instanceadmin/interface.go
@@ -21,11 +21,13 @@ import (
 	"github.com/googleapis/gax-go/v2"
 )
 
+// Use this interface instead of instance.InstanceAdminClient to support mocking.
 type InstanceAdminClient interface {
 	GetInstance(ctx context.Context, req *instancepb.GetInstanceRequest, opts ...gax.CallOption) (*instancepb.Instance, error)
 	GetInstanceConfig(ctx context.Context, req *instancepb.GetInstanceConfigRequest, opts ...gax.CallOption) (*instancepb.InstanceConfig, error)
 }
 
+// This implements the InstanceAdminClient interface. This is the primary implementation that should be used in all places other than tests.
 type InstanceAdminClientImpl struct {
 	client *instance.InstanceAdminClient
 }

--- a/accessors/clients/spanner/instanceadmin/interface.go
+++ b/accessors/clients/spanner/instanceadmin/interface.go
@@ -1,0 +1,47 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package spinstanceadmin
+
+import (
+	"context"
+
+	instance "cloud.google.com/go/spanner/admin/instance/apiv1"
+	"cloud.google.com/go/spanner/admin/instance/apiv1/instancepb"
+	"github.com/googleapis/gax-go/v2"
+)
+
+type InstanceAdminClient interface {
+	GetInstance(ctx context.Context, req *instancepb.GetInstanceRequest, opts ...gax.CallOption) (*instancepb.Instance, error)
+	GetInstanceConfig(ctx context.Context, req *instancepb.GetInstanceConfigRequest, opts ...gax.CallOption) (*instancepb.InstanceConfig, error)
+}
+
+type InstanceAdminClientImpl struct {
+	client *instance.InstanceAdminClient
+}
+
+func NewInstanceAdminClientImpl(ctx context.Context) (*InstanceAdminClientImpl, error) {
+	c, err := GetOrCreateClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return &InstanceAdminClientImpl{client: c}, nil
+}
+
+func (c *InstanceAdminClientImpl) GetInstance(ctx context.Context, req *instancepb.GetInstanceRequest, opts ...gax.CallOption) (*instancepb.Instance, error) {
+	return c.client.GetInstance(ctx, req, opts...)
+}
+
+func (c *InstanceAdminClientImpl) GetInstanceConfig(ctx context.Context, req *instancepb.GetInstanceConfigRequest, opts ...gax.CallOption) (*instancepb.InstanceConfig, error) {
+	return c.client.GetInstanceConfig(ctx, req, opts...)
+}

--- a/accessors/clients/spanner/instanceadmin/mocks.go
+++ b/accessors/clients/spanner/instanceadmin/mocks.go
@@ -12,3 +12,23 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 package spinstanceadmin
+
+import (
+	"context"
+
+	"cloud.google.com/go/spanner/admin/instance/apiv1/instancepb"
+	"github.com/googleapis/gax-go/v2"
+)
+
+type InstanceAdminClientMock struct {
+	GetInstanceMock       func(ctx context.Context, req *instancepb.GetInstanceRequest, opts ...gax.CallOption) (*instancepb.Instance, error)
+	GetInstanceConfigMock func(ctx context.Context, req *instancepb.GetInstanceConfigRequest, opts ...gax.CallOption) (*instancepb.InstanceConfig, error)
+}
+
+func (iac *InstanceAdminClientMock) GetInstance(ctx context.Context, req *instancepb.GetInstanceRequest, opts ...gax.CallOption) (*instancepb.Instance, error) {
+	return iac.GetInstanceMock(ctx, req, opts...)
+}
+
+func (iac *InstanceAdminClientMock) GetInstanceConfig(ctx context.Context, req *instancepb.GetInstanceConfigRequest, opts ...gax.CallOption) (*instancepb.InstanceConfig, error) {
+	return iac.GetInstanceConfigMock(ctx, req, opts...)
+}

--- a/accessors/clients/spanner/instanceadmin/mocks.go
+++ b/accessors/clients/spanner/instanceadmin/mocks.go
@@ -20,6 +20,8 @@ import (
 	"github.com/googleapis/gax-go/v2"
 )
 
+// Mock that implements the InstanceAdminClient interface.
+// Pass in unit tests where InstanceAdminClient is an input parameter.
 type InstanceAdminClientMock struct {
 	GetInstanceMock       func(ctx context.Context, req *instancepb.GetInstanceRequest, opts ...gax.CallOption) (*instancepb.Instance, error)
 	GetInstanceConfigMock func(ctx context.Context, req *instancepb.GetInstanceConfigRequest, opts ...gax.CallOption) (*instancepb.InstanceConfig, error)

--- a/accessors/clients/spanner/instanceadmin/mocks.go
+++ b/accessors/clients/spanner/instanceadmin/mocks.go
@@ -1,0 +1,14 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package spinstanceadmin

--- a/accessors/clients/spanner/instanceadmin/spanner_instance_admin.go
+++ b/accessors/clients/spanner/instanceadmin/spanner_instance_admin.go
@@ -24,11 +24,15 @@ import (
 var once sync.Once
 var instanceAdminClient *instance.InstanceAdminClient
 
+// This function is declared as a global variable to make it testable. The unit
+// tests edit this function, acting like a double.
+var newInstanceAdminClient = instance.NewInstanceAdminClient
+
 func GetOrCreateClient(ctx context.Context) (*instance.InstanceAdminClient, error) {
 	var err error
 	if instanceAdminClient == nil {
 		once.Do(func() {
-			instanceAdminClient, err = instance.NewInstanceAdminClient(ctx)
+			instanceAdminClient, err = newInstanceAdminClient(ctx)
 		})
 		if err != nil {
 			return nil, fmt.Errorf("failed to create spanner instance admin client: %v", err)

--- a/accessors/clients/spanner/instanceadmin/spanner_instance_admin.go
+++ b/accessors/clients/spanner/instanceadmin/spanner_instance_admin.go
@@ -25,7 +25,7 @@ var once sync.Once
 var instanceAdminClient *instance.InstanceAdminClient
 
 // This function is declared as a global variable to make it testable. The unit
-// tests edit this function, acting like a double.
+// tests update this function, acting like a double.
 var newInstanceAdminClient = instance.NewInstanceAdminClient
 
 func GetOrCreateClient(ctx context.Context) (*instance.InstanceAdminClient, error) {

--- a/accessors/clients/spanner/instanceadmin/spanner_instance_admin.go
+++ b/accessors/clients/spanner/instanceadmin/spanner_instance_admin.go
@@ -19,8 +19,6 @@ import (
 	"sync"
 
 	instance "cloud.google.com/go/spanner/admin/instance/apiv1"
-	"cloud.google.com/go/spanner/admin/instance/apiv1/instancepb"
-	"github.com/googleapis/gax-go/v2"
 )
 
 var once sync.Once
@@ -42,29 +40,4 @@ func GetOrCreateClient(ctx context.Context) (*instance.InstanceAdminClient, erro
 		return instanceAdminClient, nil
 	}
 	return instanceAdminClient, nil
-}
-
-type InstanceAdminClient interface {
-	GetInstance(ctx context.Context, req *instancepb.GetInstanceRequest, opts ...gax.CallOption) (*instancepb.Instance, error)
-	GetInstanceConfig(ctx context.Context, req *instancepb.GetInstanceConfigRequest, opts ...gax.CallOption) (*instancepb.InstanceConfig, error)
-}
-
-type InstanceAdminClientImpl struct {
-	client *instance.InstanceAdminClient
-}
-
-func NewInstanceAdminClientImpl(ctx context.Context) (*InstanceAdminClientImpl, error) {
-	c, err := GetOrCreateClient(ctx)
-	if err != nil {
-		return nil, err
-	}
-	return &InstanceAdminClientImpl{client: c}, nil
-}
-
-func (c *InstanceAdminClientImpl) GetInstance(ctx context.Context, req *instancepb.GetInstanceRequest, opts ...gax.CallOption) (*instancepb.Instance, error) {
-	return c.client.GetInstance(ctx, req, opts...)
-}
-
-func (c *InstanceAdminClientImpl) GetInstanceConfig(ctx context.Context, req *instancepb.GetInstanceConfigRequest, opts ...gax.CallOption) (*instancepb.InstanceConfig, error) {
-	return c.client.GetInstanceConfig(ctx, req, opts...)
 }

--- a/accessors/clients/spanner/instanceadmin/spanner_instance_admin.go
+++ b/accessors/clients/spanner/instanceadmin/spanner_instance_admin.go
@@ -1,0 +1,39 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package spinstanceadmin
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	instance "cloud.google.com/go/spanner/admin/instance/apiv1"
+)
+
+var once sync.Once
+var instanceAdminClient *instance.InstanceAdminClient
+
+func GetOrCreateClient(ctx context.Context) (*instance.InstanceAdminClient, error) {
+	var err error
+	if instanceAdminClient == nil {
+		once.Do(func() {
+			instanceAdminClient, err = instance.NewInstanceAdminClient(ctx)
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to create spanner instance admin client: %v", err)
+		}
+		return instanceAdminClient, nil
+	}
+	return instanceAdminClient, nil
+}

--- a/accessors/clients/spanner/instanceadmin/spanner_instance_admin.go
+++ b/accessors/clients/spanner/instanceadmin/spanner_instance_admin.go
@@ -19,6 +19,8 @@ import (
 	"sync"
 
 	instance "cloud.google.com/go/spanner/admin/instance/apiv1"
+	"cloud.google.com/go/spanner/admin/instance/apiv1/instancepb"
+	"github.com/googleapis/gax-go/v2"
 )
 
 var once sync.Once
@@ -40,4 +42,29 @@ func GetOrCreateClient(ctx context.Context) (*instance.InstanceAdminClient, erro
 		return instanceAdminClient, nil
 	}
 	return instanceAdminClient, nil
+}
+
+type InstanceAdminClient interface {
+	GetInstance(ctx context.Context, req *instancepb.GetInstanceRequest, opts ...gax.CallOption) (*instancepb.Instance, error)
+	GetInstanceConfig(ctx context.Context, req *instancepb.GetInstanceConfigRequest, opts ...gax.CallOption) (*instancepb.InstanceConfig, error)
+}
+
+type InstanceAdminClientImpl struct {
+	client *instance.InstanceAdminClient
+}
+
+func NewInstanceAdminClientImpl(ctx context.Context) (*InstanceAdminClientImpl, error) {
+	c, err := GetOrCreateClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return &InstanceAdminClientImpl{client: c}, nil
+}
+
+func (c *InstanceAdminClientImpl) GetInstance(ctx context.Context, req *instancepb.GetInstanceRequest, opts ...gax.CallOption) (*instancepb.Instance, error) {
+	return c.client.GetInstance(ctx, req, opts...)
+}
+
+func (c *InstanceAdminClientImpl) GetInstanceConfig(ctx context.Context, req *instancepb.GetInstanceConfigRequest, opts ...gax.CallOption) (*instancepb.InstanceConfig, error) {
+	return c.client.GetInstanceConfig(ctx, req, opts...)
 }

--- a/accessors/clients/spanner/instanceadmin/spanner_instance_admin_test.go
+++ b/accessors/clients/spanner/instanceadmin/spanner_instance_admin_test.go
@@ -12,3 +12,105 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 package spinstanceadmin
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sync"
+	"testing"
+
+	instance "cloud.google.com/go/spanner/admin/instance/apiv1"
+	"github.com/GoogleCloudPlatform/spanner-migration-tool/logger"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+	"google.golang.org/api/option"
+)
+
+func init() {
+	logger.Log = zap.NewNop()
+}
+
+func TestMain(m *testing.M) {
+	res := m.Run()
+	os.Exit(res)
+}
+
+func resetTest() {
+	instanceAdminClient = nil
+	once = sync.Once{}
+}
+
+func TestGetOrCreateClient_Basic(t *testing.T) {
+	resetTest()
+	ctx := context.Background()
+	oldFunc := newInstanceAdminClient
+	defer func() { newInstanceAdminClient = oldFunc }()
+	newInstanceAdminClient = func(ctx context.Context, opts ...option.ClientOption) (*instance.InstanceAdminClient, error) {
+		return &instance.InstanceAdminClient{}, nil
+	}
+	c, err := GetOrCreateClient(ctx)
+	assert.NotNil(t, c)
+	assert.Nil(t, err)
+}
+
+func TestGetOrCreateClient_OnlyOnceViaSync(t *testing.T) {
+	resetTest()
+	ctx := context.Background()
+	oldFunc := newInstanceAdminClient
+	defer func() { newInstanceAdminClient = oldFunc }()
+
+	newInstanceAdminClient = func(ctx context.Context, opts ...option.ClientOption) (*instance.InstanceAdminClient, error) {
+		return &instance.InstanceAdminClient{}, nil
+	}
+	c, err := GetOrCreateClient(ctx)
+	assert.NotNil(t, c)
+	assert.Nil(t, err)
+	// Explicitly set the client to nil. Running GetOrCreateClient should not create a
+	// new client since sync would already be executed.
+	instanceAdminClient = nil
+	newInstanceAdminClient = func(ctx context.Context, opts ...option.ClientOption) (*instance.InstanceAdminClient, error) {
+		return nil, fmt.Errorf("test error")
+	}
+	c, err = GetOrCreateClient(ctx)
+	assert.Nil(t, c)
+	assert.Nil(t, err)
+}
+
+func TestGetOrCreateClient_OnlyOnceViaIf(t *testing.T) {
+	resetTest()
+	ctx := context.Background()
+	oldFunc := newInstanceAdminClient
+	defer func() { newInstanceAdminClient = oldFunc }()
+
+	newInstanceAdminClient = func(ctx context.Context, opts ...option.ClientOption) (*instance.InstanceAdminClient, error) {
+		return &instance.InstanceAdminClient{}, nil
+	}
+	oldC, err := GetOrCreateClient(ctx)
+	assert.NotNil(t, oldC)
+	assert.Nil(t, err)
+
+	// Explicitly reset once. Running GetOrCreateClient should not create a
+	// new client the if condition should prevent it.
+	once = sync.Once{}
+	newInstanceAdminClient = func(ctx context.Context, opts ...option.ClientOption) (*instance.InstanceAdminClient, error) {
+		return nil, fmt.Errorf("test error")
+	}
+	newC, err := GetOrCreateClient(ctx)
+	assert.Equal(t, oldC, newC)
+	assert.Nil(t, err)
+}
+
+func TestGetOrCreateClient_Error(t *testing.T) {
+	resetTest()
+	ctx := context.Background()
+	oldFunc := newInstanceAdminClient
+	defer func() { newInstanceAdminClient = oldFunc }()
+
+	newInstanceAdminClient = func(ctx context.Context, opts ...option.ClientOption) (*instance.InstanceAdminClient, error) {
+		return nil, fmt.Errorf("test error")
+	}
+	c, err := GetOrCreateClient(ctx)
+	assert.Nil(t, c)
+	assert.NotNil(t, err)
+}

--- a/accessors/clients/spanner/instanceadmin/spanner_instance_admin_test.go
+++ b/accessors/clients/spanner/instanceadmin/spanner_instance_admin_test.go
@@ -1,0 +1,14 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package spinstanceadmin

--- a/accessors/clients/storage/interface.go
+++ b/accessors/clients/storage/interface.go
@@ -20,21 +20,25 @@ import (
 	"cloud.google.com/go/storage"
 )
 
+// Use this interface instead of storage.Client to support mocking.
 type StorageClient interface {
 	Bucket(name string) BucketHandle
 }
 
+// Use this interface instead of storage.BucketHandle to support mocking.
 type BucketHandle interface {
 	Create(ctx context.Context, projectID string, attrs *storage.BucketAttrs) (err error)
 	Update(ctx context.Context, uattrs storage.BucketAttrsToUpdate) (attrs *storage.BucketAttrs, err error)
 	Object(name string) ObjectHandle
 }
 
+// Use this interface instead of storage.ObjectHandle to support mocking.
 type ObjectHandle interface {
 	NewWriter(ctx context.Context) io.WriteCloser
 	NewReader(ctx context.Context) (io.ReadCloser, error)
 }
 
+// This implements the StorageClient interface. This is the primary implementation that should be used in all places other than tests.
 type StorageClientImpl struct {
 	client *storage.Client
 }
@@ -51,6 +55,7 @@ func (c *StorageClientImpl) Bucket(name string) BucketHandle {
 	return &BucketHandleImpl{bucketHandle: c.client.Bucket(name)}
 }
 
+// This implements the BucketHandle interface. This is the primary implementation that should be used in all places other than tests.
 type BucketHandleImpl struct {
 	bucketHandle *storage.BucketHandle
 }
@@ -67,6 +72,7 @@ func (b *BucketHandleImpl) Object(name string) ObjectHandle {
 	return &ObjectHandleImpl{objectHandle: b.bucketHandle.Object(name)}
 }
 
+// This implements the ObjectHandle interface. This is the primary implementation that should be used in all places other than tests.
 type ObjectHandleImpl struct {
 	objectHandle *storage.ObjectHandle
 }

--- a/accessors/clients/storage/interface.go
+++ b/accessors/clients/storage/interface.go
@@ -1,0 +1,80 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package storageclient
+
+import (
+	"context"
+	"io"
+
+	"cloud.google.com/go/storage"
+)
+
+type StorageClient interface {
+	Bucket(name string) BucketHandle
+}
+
+type BucketHandle interface {
+	Create(ctx context.Context, projectID string, attrs *storage.BucketAttrs) (err error)
+	Update(ctx context.Context, uattrs storage.BucketAttrsToUpdate) (attrs *storage.BucketAttrs, err error)
+	Object(name string) ObjectHandle
+}
+
+type ObjectHandle interface {
+	NewWriter(ctx context.Context) io.WriteCloser
+	NewReader(ctx context.Context) (io.ReadCloser, error)
+}
+
+type StorageClientImpl struct {
+	client *storage.Client
+}
+
+func NewStorageClientImpl(ctx context.Context) (*StorageClientImpl, error) {
+	c, err := GetOrCreateClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return &StorageClientImpl{client: c}, nil
+}
+
+func (c *StorageClientImpl) Bucket(name string) BucketHandle {
+	return &BucketHandleImpl{bucketHandle: c.client.Bucket(name)}
+}
+
+type BucketHandleImpl struct {
+	bucketHandle *storage.BucketHandle
+}
+
+func (b *BucketHandleImpl) Create(ctx context.Context, projectID string, attrs *storage.BucketAttrs) (err error) {
+	return b.bucketHandle.Create(ctx, projectID, attrs)
+}
+
+func (b *BucketHandleImpl) Update(ctx context.Context, uattrs storage.BucketAttrsToUpdate) (attrs *storage.BucketAttrs, err error) {
+	return b.bucketHandle.Update(ctx, uattrs)
+}
+
+func (b *BucketHandleImpl) Object(name string) ObjectHandle {
+	return &ObjectHandleImpl{objectHandle: b.bucketHandle.Object(name)}
+}
+
+type ObjectHandleImpl struct {
+	objectHandle *storage.ObjectHandle
+}
+
+func (o *ObjectHandleImpl) NewWriter(ctx context.Context) io.WriteCloser {
+	return o.objectHandle.NewWriter(ctx)
+}
+
+func (o *ObjectHandleImpl) NewReader(ctx context.Context) (io.ReadCloser, error) {
+	return o.objectHandle.NewReader(ctx)
+}

--- a/accessors/clients/storage/mocks.go
+++ b/accessors/clients/storage/mocks.go
@@ -12,3 +12,75 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 package storageclient
+
+import (
+	"context"
+	"io"
+
+	"cloud.google.com/go/storage"
+)
+
+type StorageClientMock struct {
+	BucketMock func(name string) BucketHandle
+}
+
+func (scm *StorageClientMock) Bucket(name string) BucketHandle {
+	return scm.BucketMock(name)
+}
+
+type BucketHandleMock struct {
+	CreateMock func(ctx context.Context, projectID string, attrs *storage.BucketAttrs) (err error)
+	UpdateMock func(ctx context.Context, uattrs storage.BucketAttrsToUpdate) (attrs *storage.BucketAttrs, err error)
+	ObjectMock func(name string) ObjectHandle
+}
+
+func (b *BucketHandleMock) Create(ctx context.Context, projectID string, attrs *storage.BucketAttrs) (err error) {
+	return b.CreateMock(ctx, projectID, attrs)
+}
+
+func (b *BucketHandleMock) Update(ctx context.Context, uattrs storage.BucketAttrsToUpdate) (attrs *storage.BucketAttrs, err error) {
+	return b.UpdateMock(ctx, uattrs)
+}
+
+func (b *BucketHandleMock) Object(name string) ObjectHandle {
+	return b.ObjectMock(name)
+}
+
+type ObjectHandleMock struct {
+	NewWriterMock func(ctx context.Context) io.WriteCloser
+	NewReaderMock func(ctx context.Context) (io.ReadCloser, error)
+}
+
+func (o *ObjectHandleMock) NewWriter(ctx context.Context) io.WriteCloser {
+	return o.NewWriterMock(ctx)
+}
+
+func (o *ObjectHandleMock) NewReader(ctx context.Context) (io.ReadCloser, error) {
+	return o.NewReaderMock(ctx)
+}
+
+type WriterMock struct {
+	WriteMock func(p []byte) (n int, err error)
+	CloseMock func() error
+}
+
+func (w *WriterMock) Write(p []byte) (n int, err error) {
+	return w.WriteMock(p)
+}
+
+func (w *WriterMock) Close() error {
+	return w.CloseMock()
+}
+
+type ReaderMock struct {
+	ReadMock  func(p []byte) (n int, err error)
+	CloseMock func() error
+}
+
+func (r *ReaderMock) Read(p []byte) (n int, err error) {
+	return r.ReadMock(p)
+}
+
+func (r *ReaderMock) Close() error {
+	return r.CloseMock()
+}

--- a/accessors/clients/storage/mocks.go
+++ b/accessors/clients/storage/mocks.go
@@ -20,6 +20,8 @@ import (
 	"cloud.google.com/go/storage"
 )
 
+// Mock that implements the StorageClient interface.
+// Pass in unit tests where StorageClient is an input parameter.
 type StorageClientMock struct {
 	BucketMock func(name string) BucketHandle
 }
@@ -28,6 +30,8 @@ func (scm *StorageClientMock) Bucket(name string) BucketHandle {
 	return scm.BucketMock(name)
 }
 
+// Mock that implements the BucketHandle interface.
+// Pass in unit tests where BucketHandle is an input parameter.
 type BucketHandleMock struct {
 	CreateMock func(ctx context.Context, projectID string, attrs *storage.BucketAttrs) (err error)
 	UpdateMock func(ctx context.Context, uattrs storage.BucketAttrsToUpdate) (attrs *storage.BucketAttrs, err error)
@@ -46,6 +50,8 @@ func (b *BucketHandleMock) Object(name string) ObjectHandle {
 	return b.ObjectMock(name)
 }
 
+// Mock that implements the ObjectHandle interface.
+// Pass in unit tests where ObjectHandle is an input parameter.
 type ObjectHandleMock struct {
 	NewWriterMock func(ctx context.Context) io.WriteCloser
 	NewReaderMock func(ctx context.Context) (io.ReadCloser, error)
@@ -59,6 +65,8 @@ func (o *ObjectHandleMock) NewReader(ctx context.Context) (io.ReadCloser, error)
 	return o.NewReaderMock(ctx)
 }
 
+// Mock that implements the io.WriteCloser interface.
+// Pass in unit tests where io.WriteCloser is an input parameter.
 type WriterMock struct {
 	WriteMock func(p []byte) (n int, err error)
 	CloseMock func() error
@@ -72,6 +80,8 @@ func (w *WriterMock) Close() error {
 	return w.CloseMock()
 }
 
+// Mock that implements the io.ReadCloser interface.
+// Pass in unit tests where io.ReadCloser is an input parameter.
 type ReaderMock struct {
 	ReadMock  func(p []byte) (n int, err error)
 	CloseMock func() error

--- a/accessors/clients/storage/mocks.go
+++ b/accessors/clients/storage/mocks.go
@@ -1,0 +1,14 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package storageclient

--- a/accessors/clients/storage/storage_client.go
+++ b/accessors/clients/storage/storage_client.go
@@ -24,11 +24,15 @@ import (
 var once sync.Once
 var gcsClient *storage.Client
 
+// This function is declared as a global variable to make it testable. The unit
+// tests edit this function, acting like a double.
+var newClient = storage.NewClient
+
 func GetOrCreateClient(ctx context.Context) (*storage.Client, error) {
 	var err error
 	if gcsClient == nil {
 		once.Do(func() {
-			gcsClient, err = storage.NewClient(ctx)
+			gcsClient, err = newClient(ctx)
 		})
 		if err != nil {
 			return nil, fmt.Errorf("failed to create storage client: %v", err)

--- a/accessors/clients/storage/storage_client.go
+++ b/accessors/clients/storage/storage_client.go
@@ -25,7 +25,7 @@ var once sync.Once
 var gcsClient *storage.Client
 
 // This function is declared as a global variable to make it testable. The unit
-// tests edit this function, acting like a double.
+// tests update this function, acting like a double.
 var newClient = storage.NewClient
 
 func GetOrCreateClient(ctx context.Context) (*storage.Client, error) {

--- a/accessors/clients/storage/storage_client.go
+++ b/accessors/clients/storage/storage_client.go
@@ -16,6 +16,7 @@ package storageclient
 import (
 	"context"
 	"fmt"
+	"io"
 	"sync"
 
 	"cloud.google.com/go/storage"
@@ -40,4 +41,63 @@ func GetOrCreateClient(ctx context.Context) (*storage.Client, error) {
 		return gcsClient, nil
 	}
 	return gcsClient, nil
+}
+
+type StorageClient interface {
+	Bucket(name string) BucketHandle
+}
+
+type BucketHandle interface {
+	Create(ctx context.Context, projectID string, attrs *storage.BucketAttrs) (err error)
+	Update(ctx context.Context, uattrs storage.BucketAttrsToUpdate) (attrs *storage.BucketAttrs, err error)
+	Object(name string) ObjectHandle
+}
+
+type ObjectHandle interface {
+	NewWriter(ctx context.Context) io.WriteCloser
+	NewReader(ctx context.Context) (io.ReadCloser, error)
+}
+
+type StorageClientImpl struct {
+	client *storage.Client
+}
+
+func NewStorageClientImpl(ctx context.Context) (*StorageClientImpl, error) {
+	c, err := GetOrCreateClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return &StorageClientImpl{client: c}, nil
+}
+
+func (c *StorageClientImpl) Bucket(name string) BucketHandle {
+	return &BucketHandleImpl{bucketHandle: c.client.Bucket(name)}
+}
+
+type BucketHandleImpl struct {
+	bucketHandle *storage.BucketHandle
+}
+
+func (b *BucketHandleImpl) Create(ctx context.Context, projectID string, attrs *storage.BucketAttrs) (err error) {
+	return b.bucketHandle.Create(ctx, projectID, attrs)
+}
+
+func (b *BucketHandleImpl) Update(ctx context.Context, uattrs storage.BucketAttrsToUpdate) (attrs *storage.BucketAttrs, err error) {
+	return b.bucketHandle.Update(ctx, uattrs)
+}
+
+func (b *BucketHandleImpl) Object(name string) ObjectHandle {
+	return &ObjectHandleImpl{objectHandle: b.bucketHandle.Object(name)}
+}
+
+type ObjectHandleImpl struct {
+	objectHandle *storage.ObjectHandle
+}
+
+func (o *ObjectHandleImpl) NewWriter(ctx context.Context) io.WriteCloser {
+	return o.objectHandle.NewWriter(ctx)
+}
+
+func (o *ObjectHandleImpl) NewReader(ctx context.Context) (io.ReadCloser, error) {
+	return o.objectHandle.NewReader(ctx)
 }

--- a/accessors/clients/storage/storage_client.go
+++ b/accessors/clients/storage/storage_client.go
@@ -1,0 +1,39 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package storageclient
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"cloud.google.com/go/storage"
+)
+
+var once sync.Once
+var gcsClient *storage.Client
+
+func GetOrCreateClient(ctx context.Context) (*storage.Client, error) {
+	var err error
+	if gcsClient == nil {
+		once.Do(func() {
+			gcsClient, err = storage.NewClient(ctx)
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to create storage client: %v", err)
+		}
+		return gcsClient, nil
+	}
+	return gcsClient, nil
+}

--- a/accessors/clients/storage/storage_client_test.go
+++ b/accessors/clients/storage/storage_client_test.go
@@ -1,0 +1,14 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package storageclient

--- a/accessors/clients/storage/storage_client_test.go
+++ b/accessors/clients/storage/storage_client_test.go
@@ -12,3 +12,106 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 package storageclient
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sync"
+	"testing"
+
+	"cloud.google.com/go/storage"
+	"github.com/GoogleCloudPlatform/spanner-migration-tool/logger"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+	"google.golang.org/api/option"
+)
+
+func init() {
+	logger.Log = zap.NewNop()
+}
+
+func TestMain(m *testing.M) {
+	res := m.Run()
+	os.Exit(res)
+}
+
+func resetTest() {
+	gcsClient = nil
+	once = sync.Once{}
+}
+
+func TestGetOrCreateClient_Basic(t *testing.T) {
+	resetTest()
+	ctx := context.Background()
+	oldFunc := newClient
+	defer func() { newClient = oldFunc }()
+	newClient = func(ctx context.Context, opts ...option.ClientOption) (*storage.Client, error) {
+		return &storage.Client{}, nil
+	}
+	c, err := GetOrCreateClient(ctx)
+	assert.NotNil(t, c)
+	assert.Nil(t, err)
+}
+
+func TestGetOrCreateClient_OnlyOnceViaSync(t *testing.T) {
+	resetTest()
+	ctx := context.Background()
+	oldFunc := newClient
+	defer func() { newClient = oldFunc }()
+
+	newClient = func(ctx context.Context, opts ...option.ClientOption) (*storage.Client, error) {
+		return &storage.Client{}, nil
+	}
+	c, err := GetOrCreateClient(ctx)
+	assert.NotNil(t, c)
+	assert.Nil(t, err)
+	// Explicitly set the client to nil. Running GetOrCreateClient should not create a
+	// new client since sync would already be executed.
+	gcsClient = nil
+
+	newClient = func(ctx context.Context, opts ...option.ClientOption) (*storage.Client, error) {
+		return nil, fmt.Errorf("test error")
+	}
+	c, err = GetOrCreateClient(ctx)
+	assert.Nil(t, c)
+	assert.Nil(t, err)
+}
+
+func TestGetOrCreateClient_OnlyOnceViaIf(t *testing.T) {
+	resetTest()
+	ctx := context.Background()
+	oldFunc := newClient
+	defer func() { newClient = oldFunc }()
+
+	newClient = func(ctx context.Context, opts ...option.ClientOption) (*storage.Client, error) {
+		return &storage.Client{}, nil
+	}
+	oldC, err := GetOrCreateClient(ctx)
+	assert.NotNil(t, oldC)
+	assert.Nil(t, err)
+
+	// Explicitly reset once. Running GetOrCreateClient should not create a
+	// new client the if condition should prevent it.
+	once = sync.Once{}
+	newClient = func(ctx context.Context, opts ...option.ClientOption) (*storage.Client, error) {
+		return nil, fmt.Errorf("test error")
+	}
+	newC, err := GetOrCreateClient(ctx)
+	assert.Equal(t, oldC, newC)
+	assert.Nil(t, err)
+}
+
+func TestGetOrCreateClient_Error(t *testing.T) {
+	resetTest()
+	ctx := context.Background()
+	oldFunc := newClient
+	defer func() { newClient = oldFunc }()
+
+	newClient = func(ctx context.Context, opts ...option.ClientOption) (*storage.Client, error) {
+		return nil, fmt.Errorf("test error")
+	}
+	c, err := GetOrCreateClient(ctx)
+	assert.Nil(t, c)
+	assert.NotNil(t, err)
+}

--- a/accessors/dataflow/dataflow_accessor.go
+++ b/accessors/dataflow/dataflow_accessor.go
@@ -15,12 +15,14 @@ package dataflowaccessor
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"sort"
 	"strings"
 
 	"cloud.google.com/go/dataflow/apiv1beta3/dataflowpb"
 	dataflowclient "github.com/GoogleCloudPlatform/spanner-migration-tool/accessors/clients/dataflow"
+	storageacc "github.com/GoogleCloudPlatform/spanner-migration-tool/accessors/storage"
 	"github.com/GoogleCloudPlatform/spanner-migration-tool/logger"
 	"golang.org/x/exp/maps"
 )
@@ -175,4 +177,17 @@ func formatAdditionalUserLabels(labels map[string]string) string {
 		res = append(res, fmt.Sprintf("%s=%s", key, value))
 	}
 	return strings.Join(res, ",")
+}
+
+func UnmarshalDataflowTuningConfig(ctx context.Context, filePath string) (DataflowTuningConfig, error) {
+	jsonStr, err := storageacc.ReadAnyFile(ctx, filePath)
+	if err != nil {
+		return DataflowTuningConfig{}, err
+	}
+	tuningCfg := DataflowTuningConfig{}
+	err = json.Unmarshal([]byte(jsonStr), &tuningCfg)
+	if err != nil {
+		return DataflowTuningConfig{}, err
+	}
+	return tuningCfg, nil
 }

--- a/accessors/dataflow/dataflow_accessor.go
+++ b/accessors/dataflow/dataflow_accessor.go
@@ -15,14 +15,12 @@ package dataflowaccessor
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"sort"
 	"strings"
 
 	"cloud.google.com/go/dataflow/apiv1beta3/dataflowpb"
 	dataflowclient "github.com/GoogleCloudPlatform/spanner-migration-tool/accessors/clients/dataflow"
-	storageacc "github.com/GoogleCloudPlatform/spanner-migration-tool/accessors/storage"
 	"github.com/GoogleCloudPlatform/spanner-migration-tool/logger"
 	"golang.org/x/exp/maps"
 )
@@ -177,17 +175,4 @@ func formatAdditionalUserLabels(labels map[string]string) string {
 		res = append(res, fmt.Sprintf("%s=%s", key, value))
 	}
 	return strings.Join(res, ",")
-}
-
-func UnmarshalDataflowTuningConfig(ctx context.Context, filePath string) (DataflowTuningConfig, error) {
-	jsonStr, err := storageacc.ReadAnyFile(ctx, filePath)
-	if err != nil {
-		return DataflowTuningConfig{}, err
-	}
-	tuningCfg := DataflowTuningConfig{}
-	err = json.Unmarshal([]byte(jsonStr), &tuningCfg)
-	if err != nil {
-		return DataflowTuningConfig{}, err
-	}
-	return tuningCfg, nil
 }

--- a/accessors/dataflow/dataflow_accessor.go
+++ b/accessors/dataflow/dataflow_accessor.go
@@ -25,12 +25,14 @@ import (
 	"golang.org/x/exp/maps"
 )
 
+// The DataflowAccessor provides methods that internally use the dataflow client. Methods should only contain generic logic here that can be used by multiple workflows.
 type DataflowAccessor interface {
 	// This function takes the template parameters (@parameters) and runtime environment config (@cfg) as input, and returns
 	// the generated jobId, equivalentGcloudCommand and error if any.
-	LaunchFlexTemplate(ctx context.Context, c dataflowclient.DataflowClient, parameters map[string]string, cfg DataflowTuningConfig) (string, string, error)
+	LaunchDataflowTemplate(ctx context.Context, c dataflowclient.DataflowClient, parameters map[string]string, cfg DataflowTuningConfig) (string, string, error)
 }
 
+// This implements the DataflowAccessor interface. This is the primary implementation that should be used in all places other than tests.
 type DataflowAccessorImpl struct{}
 
 func (dfA *DataflowAccessorImpl) LaunchDataflowTemplate(ctx context.Context, c dataflowclient.DataflowClient, parameters map[string]string, cfg DataflowTuningConfig) (string, string, error) {

--- a/accessors/dataflow/dataflow_accessor_test.go
+++ b/accessors/dataflow/dataflow_accessor_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"cloud.google.com/go/dataflow/apiv1beta3/dataflowpb"
+	dataflowclient "github.com/GoogleCloudPlatform/spanner-migration-tool/accessors/clients/dataflow"
 	"github.com/GoogleCloudPlatform/spanner-migration-tool/logger"
 	"github.com/google/go-cmp/cmp"
 	"github.com/googleapis/gax-go/v2"
@@ -157,14 +158,6 @@ func getExpectedGcloudCmd2() string {
 		"transformationContextFilePath=gs://transformationContext.json"
 }
 
-type DataflowClientMock struct {
-	LaunchFlexTemplateMock func(ctx context.Context, req *dataflowpb.LaunchFlexTemplateRequest, opts ...gax.CallOption) (*dataflowpb.LaunchFlexTemplateResponse, error)
-}
-
-func (dcm *DataflowClientMock) LaunchFlexTemplate(ctx context.Context, req *dataflowpb.LaunchFlexTemplateRequest, opts ...gax.CallOption) (*dataflowpb.LaunchFlexTemplateResponse, error) {
-	return dcm.LaunchFlexTemplateMock(ctx, req, opts...)
-}
-
 func TestLaunchDataflowTemplate(t *testing.T) {
 	ctx := context.Background()
 	da := DataflowAccessorImpl{}
@@ -172,7 +165,7 @@ func TestLaunchDataflowTemplate(t *testing.T) {
 		name              string
 		params            map[string]string
 		cfg               DataflowTuningConfig
-		dcm               DataflowClientMock
+		dcm               dataflowclient.DataflowClientMock
 		expectError       bool
 		expectedJobId     string
 		expectedGcloudCmd string
@@ -181,7 +174,7 @@ func TestLaunchDataflowTemplate(t *testing.T) {
 			name:   "Basic Correct",
 			params: getParameters(),
 			cfg:    getTuningConfig(),
-			dcm: DataflowClientMock{
+			dcm: dataflowclient.DataflowClientMock{
 				LaunchFlexTemplateMock: func(ctx context.Context, req *dataflowpb.LaunchFlexTemplateRequest, opts ...gax.CallOption) (*dataflowpb.LaunchFlexTemplateResponse, error) {
 					return &dataflowpb.LaunchFlexTemplateResponse{Job: &dataflowpb.Job{Id: "1234"}}, nil
 				},
@@ -194,7 +187,7 @@ func TestLaunchDataflowTemplate(t *testing.T) {
 			name:   "Request builder error",
 			params: getParameters(),
 			cfg:    DataflowTuningConfig{Subnetwork: "test"},
-			dcm: DataflowClientMock{
+			dcm: dataflowclient.DataflowClientMock{
 				LaunchFlexTemplateMock: func(ctx context.Context, req *dataflowpb.LaunchFlexTemplateRequest, opts ...gax.CallOption) (*dataflowpb.LaunchFlexTemplateResponse, error) {
 					return &dataflowpb.LaunchFlexTemplateResponse{Job: &dataflowpb.Job{Id: "1234"}}, nil
 				},
@@ -207,7 +200,7 @@ func TestLaunchDataflowTemplate(t *testing.T) {
 			name:   "Launch flex template throws error",
 			params: getParameters(),
 			cfg:    getTuningConfig(),
-			dcm: DataflowClientMock{
+			dcm: dataflowclient.DataflowClientMock{
 				LaunchFlexTemplateMock: func(ctx context.Context, req *dataflowpb.LaunchFlexTemplateRequest, opts ...gax.CallOption) (*dataflowpb.LaunchFlexTemplateResponse, error) {
 					return nil, fmt.Errorf("test error")
 				},

--- a/accessors/dataflow/mocks.go
+++ b/accessors/dataflow/mocks.go
@@ -19,6 +19,8 @@ import (
 	dataflowclient "github.com/GoogleCloudPlatform/spanner-migration-tool/accessors/clients/dataflow"
 )
 
+// Mock that implements the DataflowAccessor interface.
+// Pass in unit tests where DataflowAccessor is an input parameter.
 type DataflowAccessorMock struct {
 	LaunchFlexTemplateMock func(ctx context.Context, c dataflowclient.DataflowClient, parameters map[string]string, cfg DataflowTuningConfig) (string, string, error)
 }

--- a/accessors/dataflow/mocks.go
+++ b/accessors/dataflow/mocks.go
@@ -1,0 +1,28 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package dataflowaccessor
+
+import (
+	"context"
+
+	dataflowclient "github.com/GoogleCloudPlatform/spanner-migration-tool/accessors/clients/dataflow"
+)
+
+type DataflowAccessorMock struct {
+	LaunchFlexTemplateMock func(ctx context.Context, c dataflowclient.DataflowClient, parameters map[string]string, cfg DataflowTuningConfig) (string, string, error)
+}
+
+func (d *DataflowAccessorMock) LaunchDataflowTemplate(ctx context.Context, c dataflowclient.DataflowClient, parameters map[string]string, cfg DataflowTuningConfig) (string, string, error) {
+	return d.LaunchFlexTemplateMock(ctx, c, parameters, cfg)
+}

--- a/accessors/helpers/dataflow/dataflow_helpers.go
+++ b/accessors/helpers/dataflow/dataflow_helpers.go
@@ -14,7 +14,7 @@
 
 // This is a package is kept with accessors because some functions import other accessors.
 // The common/utils package should not import any SMT dependency.
-package dataflowutils
+package dataflowhelpers
 
 import (
 	"context"
@@ -25,6 +25,10 @@ import (
 	storageaccessor "github.com/GoogleCloudPlatform/spanner-migration-tool/accessors/storage"
 )
 
+// This package contains common helper methods using the accessor package. This will be used by multiple flows.
+// Do not move to util since util only expects methods that do no import any other internal dependency.
+
+// Reads any local or gcs file and unmarshals the data into a DataflowTuningConfig struct.
 func UnmarshalDataflowTuningConfig(ctx context.Context, sc storageclient.StorageClient, sa storageaccessor.StorageAccessor, filePath string) (dataflowaccessor.DataflowTuningConfig, error) {
 	jsonStr, err := sa.ReadAnyFile(ctx, sc, filePath)
 	if err != nil {

--- a/accessors/helpers/dataflow/dataflow_helpers_test.go
+++ b/accessors/helpers/dataflow/dataflow_helpers_test.go
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-package dataflowutils
+package dataflowhelpers
 
 import (
 	"context"
@@ -135,7 +135,7 @@ func TestUnmarshalDataflowTuningConfig(t *testing.T) {
 	ctx := context.Background()
 	for _, tc := range testCases {
 		got, err := UnmarshalDataflowTuningConfig(ctx, nil, &tc.sam, "unused/path/due/to/mock")
-		assert.Equal(t, tc.expectError, err != nil)
-		assert.Equal(t, tc.want, got)
+		assert.Equal(t, tc.expectError, err != nil, tc.name)
+		assert.Equal(t, tc.want, got, tc.name)
 	}
 }

--- a/accessors/spanner/mocks.go
+++ b/accessors/spanner/mocks.go
@@ -20,6 +20,8 @@ import (
 	spinstanceadmin "github.com/GoogleCloudPlatform/spanner-migration-tool/accessors/clients/spanner/instanceadmin"
 )
 
+// Mock that implements the SpannerAccessor interface.
+// Pass in unit tests where SpannerAccessor is an input parameter.
 type SpannerAccessorMock struct {
 	GetDatabaseDialectMock          func(ctx context.Context, adminClient spanneradmin.AdminClient, dbURI string) (string, error)
 	CheckExistingDbMock             func(ctx context.Context, adminClient spanneradmin.AdminClient, dbURI string) (bool, error)

--- a/accessors/spanner/mocks.go
+++ b/accessors/spanner/mocks.go
@@ -1,0 +1,59 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package spanneraccessor
+
+import (
+	"context"
+
+	spanneradmin "github.com/GoogleCloudPlatform/spanner-migration-tool/accessors/clients/spanner/admin"
+	spinstanceadmin "github.com/GoogleCloudPlatform/spanner-migration-tool/accessors/clients/spanner/instanceadmin"
+)
+
+type SpannerAccessorMock struct {
+	GetDatabaseDialectMock          func(ctx context.Context, adminClient spanneradmin.AdminClient, dbURI string) (string, error)
+	CheckExistingDbMock             func(ctx context.Context, adminClient spanneradmin.AdminClient, dbURI string) (bool, error)
+	CreateEmptyDatabaseMock         func(ctx context.Context, adminClient spanneradmin.AdminClient, dbURI string) error
+	GetSpannerLeaderLocationMock    func(ctx context.Context, instanceClient spinstanceadmin.InstanceAdminClient, instanceURI string) (string, error)
+	CheckIfChangeStreamExistsMock   func(ctx context.Context, changeStreamName, dbURI string) (bool, error)
+	ValidateChangeStreamOptionsMock func(ctx context.Context, changeStreamName, dbURI string) error
+	CreateChangeStreamMock          func(ctx context.Context, adminClient spanneradmin.AdminClient, changeStreamName, dbURI string) error
+}
+
+func (sam *SpannerAccessorMock) GetDatabaseDialect(ctx context.Context, adminClient spanneradmin.AdminClient, dbURI string) (string, error) {
+	return sam.GetDatabaseDialectMock(ctx, adminClient, dbURI)
+}
+
+func (sam *SpannerAccessorMock) CheckExistingDb(ctx context.Context, adminClient spanneradmin.AdminClient, dbURI string) (bool, error) {
+	return sam.CheckExistingDbMock(ctx, adminClient, dbURI)
+}
+
+func (sam *SpannerAccessorMock) CreateEmptyDatabase(ctx context.Context, adminClient spanneradmin.AdminClient, dbURI string) error {
+	return sam.CreateEmptyDatabaseMock(ctx, adminClient, dbURI)
+}
+
+func (sam *SpannerAccessorMock) GetSpannerLeaderLocation(ctx context.Context, instanceClient spinstanceadmin.InstanceAdminClient, instanceURI string) (string, error) {
+	return sam.GetSpannerLeaderLocationMock(ctx, instanceClient, instanceURI)
+}
+
+func (sam *SpannerAccessorMock) CheckIfChangeStreamExists(ctx context.Context, changeStreamName, dbURI string) (bool, error) {
+	return sam.CheckIfChangeStreamExistsMock(ctx, changeStreamName, dbURI)
+}
+
+func (sam *SpannerAccessorMock) ValidateChangeStreamOptions(ctx context.Context, changeStreamName, dbURI string) error {
+	return sam.ValidateChangeStreamOptionsMock(ctx, changeStreamName, dbURI)
+}
+
+func (sam *SpannerAccessorMock) CreateChangeStream(ctx context.Context, adminClient spanneradmin.AdminClient, changeStreamName, dbURI string) error {
+	return sam.CreateChangeStreamMock(ctx, adminClient, changeStreamName, dbURI)
+}

--- a/accessors/spanner/spanner_accessor.go
+++ b/accessors/spanner/spanner_accessor.go
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-package spanneracc
+package spanneraccessor
 
 import (
 	"context"

--- a/accessors/spanner/spanner_accessor.go
+++ b/accessors/spanner/spanner_accessor.go
@@ -42,7 +42,7 @@ type SpannerAccessor interface {
 
 type SpannerAccessorImpl struct{}
 
-func (sp SpannerAccessorImpl) GetDatabase(ctx context.Context, dbURI string) (*databasepb.Database, error) {
+func (sp *SpannerAccessorImpl) GetDatabase(ctx context.Context, dbURI string) (*databasepb.Database, error) {
 	adminClient, err := spanneradmin.GetOrCreateClient(ctx)
 	if err != nil {
 		return nil, err
@@ -50,7 +50,7 @@ func (sp SpannerAccessorImpl) GetDatabase(ctx context.Context, dbURI string) (*d
 	return adminClient.GetDatabase(ctx, &databasepb.GetDatabaseRequest{Name: dbURI})
 }
 
-func (sp SpannerAccessorImpl) GetDatabaseDialect(ctx context.Context, dbURI string) (string, error) {
+func (sp *SpannerAccessorImpl) GetDatabaseDialect(ctx context.Context, dbURI string) (string, error) {
 	result, err := sp.GetDatabase(ctx, dbURI)
 	if err != nil {
 		return "", fmt.Errorf("cannot connect to database: %v", err)
@@ -60,7 +60,7 @@ func (sp SpannerAccessorImpl) GetDatabaseDialect(ctx context.Context, dbURI stri
 
 // CheckExistingDb checks whether the database with dbURI exists or not.
 // If API call doesn't respond then user is informed after every 5 minutes on command line.
-func (sp SpannerAccessorImpl) CheckExistingDb(ctx context.Context, dbURI string) (bool, error) {
+func (sp *SpannerAccessorImpl) CheckExistingDb(ctx context.Context, dbURI string) (bool, error) {
 	gotResponse := make(chan bool)
 	var err error
 	go func() {
@@ -83,7 +83,7 @@ func (sp SpannerAccessorImpl) CheckExistingDb(ctx context.Context, dbURI string)
 	}
 }
 
-func (sp SpannerAccessorImpl) CreateEmptyDatabase(ctx context.Context, dbURI string) error {
+func (sp *SpannerAccessorImpl) CreateEmptyDatabase(ctx context.Context, dbURI string) error {
 	adminClient, err := spanneradmin.GetOrCreateClient(ctx)
 	if err != nil {
 		return err
@@ -103,7 +103,7 @@ func (sp SpannerAccessorImpl) CreateEmptyDatabase(ctx context.Context, dbURI str
 	return nil
 }
 
-func (sp SpannerAccessorImpl) GetSpannerLeaderLocation(ctx context.Context, instanceURI string) (string, error) {
+func (sp *SpannerAccessorImpl) GetSpannerLeaderLocation(ctx context.Context, instanceURI string) (string, error) {
 	instanceClient, err := spinstanceadmin.GetOrCreateClient(ctx)
 	if err != nil {
 		return "", err
@@ -125,7 +125,7 @@ func (sp SpannerAccessorImpl) GetSpannerLeaderLocation(ctx context.Context, inst
 	return "", fmt.Errorf("no leader found for spanner instance %s while trying fetch location", instanceURI)
 }
 
-func (sp SpannerAccessorImpl) CheckIfChangeStreamExists(ctx context.Context, changeStreamName, dbURI string) (bool, error) {
+func (sp *SpannerAccessorImpl) CheckIfChangeStreamExists(ctx context.Context, changeStreamName, dbURI string) (bool, error) {
 	spClient, err := spannerclient.GetOrCreateClient(ctx, dbURI)
 	if err != nil {
 		return false, err
@@ -157,7 +157,7 @@ func (sp SpannerAccessorImpl) CheckIfChangeStreamExists(ctx context.Context, cha
 	return csExists, nil
 }
 
-func (sp SpannerAccessorImpl) ValidateChangeStreamOptions(ctx context.Context, changeStreamName, dbURI string) error {
+func (sp *SpannerAccessorImpl) ValidateChangeStreamOptions(ctx context.Context, changeStreamName, dbURI string) error {
 	spClient, err := spannerclient.GetOrCreateClient(ctx, dbURI)
 	if err != nil {
 		return err
@@ -192,7 +192,7 @@ func (sp SpannerAccessorImpl) ValidateChangeStreamOptions(ctx context.Context, c
 	return nil
 }
 
-func (sp SpannerAccessorImpl) CreateChangeStream(ctx context.Context, changeStreamName, dbURI string) error {
+func (sp *SpannerAccessorImpl) CreateChangeStream(ctx context.Context, changeStreamName, dbURI string) error {
 	spClient, _ := spanneradmin.GetOrCreateClient(ctx)
 	op, err := spClient.UpdateDatabaseDdl(ctx, &databasepb.UpdateDatabaseDdlRequest{
 		Database: dbURI,

--- a/accessors/spanner/spanner_accessor.go
+++ b/accessors/spanner/spanner_accessor.go
@@ -1,0 +1,203 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package spanneracc
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"cloud.google.com/go/spanner"
+	"cloud.google.com/go/spanner/admin/database/apiv1/databasepb"
+	"cloud.google.com/go/spanner/admin/instance/apiv1/instancepb"
+	spanneradmin "github.com/GoogleCloudPlatform/spanner-migration-tool/accessors/clients/spanner/admin"
+	spannerclient "github.com/GoogleCloudPlatform/spanner-migration-tool/accessors/clients/spanner/client"
+	spinstanceadmin "github.com/GoogleCloudPlatform/spanner-migration-tool/accessors/clients/spanner/instanceadmin"
+	"github.com/GoogleCloudPlatform/spanner-migration-tool/common/utils"
+	"google.golang.org/api/iterator"
+)
+
+func GetDatabase(ctx context.Context, dbURI string) (*databasepb.Database, error) {
+	adminClient, err := spanneradmin.GetOrCreateClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return adminClient.GetDatabase(ctx, &databasepb.GetDatabaseRequest{Name: dbURI})
+}
+
+func GetDatabaseDialect(ctx context.Context, dbURI string) (string, error) {
+	result, err := GetDatabase(ctx, dbURI)
+	if err != nil {
+		return "", fmt.Errorf("cannot connect to database: %v", err)
+	}
+	return strings.ToLower(result.DatabaseDialect.String()), nil
+}
+
+// CheckExistingDb checks whether the database with dbURI exists or not.
+// If API call doesn't respond then user is informed after every 5 minutes on command line.
+func CheckExistingDb(ctx context.Context, dbURI string) (bool, error) {
+	gotResponse := make(chan bool)
+	var err error
+	adminClient, err := spanneradmin.GetOrCreateClient(ctx)
+	if err != nil {
+		return false, err
+	}
+	go func() {
+		_, err = adminClient.GetDatabase(ctx, &databasepb.GetDatabaseRequest{Name: dbURI})
+		gotResponse <- true
+	}()
+	for {
+		select {
+		case <-time.After(5 * time.Minute):
+			fmt.Println("WARNING! API call not responding: make sure that spanner api endpoint is configured properly")
+		case <-gotResponse:
+			if err != nil {
+				if utils.ContainsAny(strings.ToLower(err.Error()), []string{"database not found"}) {
+					return false, nil
+				}
+				return false, fmt.Errorf("can't get database info: %s", err)
+			}
+			return true, nil
+		}
+	}
+}
+
+func CreateEmptyDatabase(ctx context.Context, dbURI string) error {
+	adminClient, err := spanneradmin.GetOrCreateClient(ctx)
+	if err != nil {
+		return err
+	}
+	project, instance, dbName := utils.ParseDbURI(dbURI)
+	req := &databasepb.CreateDatabaseRequest{
+		Parent:          fmt.Sprintf("projects/%s/instances/%s", project, instance),
+		CreateStatement: "CREATE DATABASE `" + dbName + "`",
+	}
+	op, err := adminClient.CreateDatabase(ctx, req)
+	if err != nil {
+		return fmt.Errorf("can't build CreateDatabaseRequest: %w", utils.AnalyzeError(err, dbURI))
+	}
+	if _, err := op.Wait(ctx); err != nil {
+		return fmt.Errorf("createDatabase call failed: %w", utils.AnalyzeError(err, dbURI))
+	}
+	return nil
+}
+
+func GetSpannerLeaderLocation(ctx context.Context, instanceURI string) (string, error) {
+	instanceClient, err := spinstanceadmin.GetOrCreateClient(ctx)
+	if err != nil {
+		return "", err
+	}
+	instanceInfo, err := instanceClient.GetInstance(ctx, &instancepb.GetInstanceRequest{Name: instanceURI})
+	if err != nil {
+		return "", err
+	}
+	instanceConfig, err := instanceClient.GetInstanceConfig(ctx, &instancepb.GetInstanceConfigRequest{Name: instanceInfo.Config})
+	if err != nil {
+		return "", err
+
+	}
+	for _, replica := range instanceConfig.Replicas {
+		if replica.DefaultLeaderLocation {
+			return replica.Location, nil
+		}
+	}
+	return "", fmt.Errorf("no leader found for spanner instance %s while trying fetch location", instanceURI)
+}
+
+func CheckIfChangeStreamExists(ctx context.Context, changeStreamName, dbURI string) (bool, error) {
+	spClient, err := spannerclient.GetOrCreateClient(ctx, dbURI)
+	if err != nil {
+		return false, err
+	}
+	stmt := spanner.Statement{
+		SQL: `SELECT * FROM information_schema.change_streams`,
+	}
+	iter := spClient.Single().Query(ctx, stmt)
+	defer iter.Stop()
+	var cs_catalog, cs_schema, cs_name string
+	var coversAll bool
+	csExists := false
+	for {
+		row, err := iter.Next()
+		if err == iterator.Done {
+			break
+		}
+		if err != nil {
+			return false, fmt.Errorf("couldn't read row from change_streams table: %w", err)
+		}
+		err = row.Columns(&cs_catalog, &cs_schema, &cs_name, &coversAll)
+		if err != nil {
+			return false, fmt.Errorf("can't scan row from change_streams table: %v", err)
+		}
+		if cs_name == changeStreamName {
+			csExists = true
+			break
+		}
+	}
+	return csExists, nil
+}
+
+func ValidateChangeStreamOptions(ctx context.Context, changeStreamName, dbURI string) error {
+	spClient, err := spannerclient.GetOrCreateClient(ctx, dbURI)
+	if err != nil {
+		return err
+	}
+	// Validate if change stream options are set correctly.
+	stmt := spanner.Statement{
+		SQL: `SELECT option_value FROM information_schema.change_stream_options
+		WHERE change_stream_name = @p1 AND option_name = 'value_capture_type'`,
+		Params: map[string]interface{}{
+			"p1": changeStreamName,
+		},
+	}
+	iter := spClient.Single().Query(ctx, stmt)
+	defer iter.Stop()
+	var option_value string
+	for {
+		row, err := iter.Next()
+		if err == iterator.Done {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("couldn't read row from change_stream_options table: %w", err)
+		}
+		err = row.Columns(&option_value)
+		if err != nil {
+			return fmt.Errorf("can't scan row from change_stream_options table: %v", err)
+		}
+		if option_value != "NEW_ROW" {
+			return fmt.Errorf("VALUE_CAPTURE_TYPE for changestream %s is not NEW_ROW. Please update the changestream option or create a new one", changeStreamName)
+		}
+	}
+	return nil
+}
+
+func CreateChangeStream(ctx context.Context, changeStreamName, dbURI string) error {
+	spClient, _ := spanneradmin.GetOrCreateClient(ctx)
+	op, err := spClient.UpdateDatabaseDdl(ctx, &databasepb.UpdateDatabaseDdlRequest{
+		Database: dbURI,
+		// TODO: create change stream for only the tables present in Spanner.
+		Statements: []string{fmt.Sprintf("CREATE CHANGE STREAM %s FOR ALL OPTIONS (value_capture_type = 'NEW_ROW')", changeStreamName)},
+	})
+	if err != nil {
+		return fmt.Errorf("cannot submit request create change stream request: %v", err)
+	}
+	if err := op.Wait(ctx); err != nil {
+		return fmt.Errorf("could not update database ddl: %v", err)
+	} else {
+		fmt.Println("Successfully created changestream", changeStreamName)
+	}
+	return nil
+}

--- a/accessors/spanner/spanner_accessor_test.go
+++ b/accessors/spanner/spanner_accessor_test.go
@@ -12,3 +12,181 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 package spanneraccessor
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"cloud.google.com/go/spanner/admin/database/apiv1/databasepb"
+	spanneradmin "github.com/GoogleCloudPlatform/spanner-migration-tool/accessors/clients/spanner/admin"
+	"github.com/GoogleCloudPlatform/spanner-migration-tool/logger"
+	"github.com/googleapis/gax-go/v2"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+)
+
+func init() {
+	logger.Log = zap.NewNop()
+}
+
+func TestMain(m *testing.M) {
+	res := m.Run()
+	os.Exit(res)
+}
+
+func TestSpannerAccessorImpl_GetDatabaseDialect(t *testing.T) {
+	testCases := []struct {
+		name        string
+		acm         spanneradmin.AdminClientMock
+		expectError bool
+		want        string
+	}{
+		{
+			name: "Basic",
+			acm: spanneradmin.AdminClientMock{
+				GetDatabaseMock: func(ctx context.Context, req *databasepb.GetDatabaseRequest, opts ...gax.CallOption) (*databasepb.Database, error) {
+					return &databasepb.Database{DatabaseDialect: databasepb.DatabaseDialect_GOOGLE_STANDARD_SQL}, nil
+				},
+			},
+			expectError: false,
+			want:        "google_standard_sql",
+		},
+		{
+			name: "Pg Dialect",
+			acm: spanneradmin.AdminClientMock{
+				GetDatabaseMock: func(ctx context.Context, req *databasepb.GetDatabaseRequest, opts ...gax.CallOption) (*databasepb.Database, error) {
+					return &databasepb.Database{DatabaseDialect: databasepb.DatabaseDialect_POSTGRESQL}, nil
+				},
+			},
+			expectError: false,
+			want:        "postgresql",
+		},
+		{
+			name: "Unspecified Dialect",
+			acm: spanneradmin.AdminClientMock{
+				GetDatabaseMock: func(ctx context.Context, req *databasepb.GetDatabaseRequest, opts ...gax.CallOption) (*databasepb.Database, error) {
+					return &databasepb.Database{DatabaseDialect: databasepb.DatabaseDialect_DATABASE_DIALECT_UNSPECIFIED}, nil
+				},
+			},
+			expectError: false,
+			want:        "database_dialect_unspecified",
+		},
+		{
+			name: "Error case",
+			acm: spanneradmin.AdminClientMock{
+				GetDatabaseMock: func(ctx context.Context, req *databasepb.GetDatabaseRequest, opts ...gax.CallOption) (*databasepb.Database, error) {
+					return nil, fmt.Errorf("test-error")
+				},
+			},
+			expectError: true,
+			want:        "",
+		},
+	}
+	ctx := context.Background()
+	spA := SpannerAccessorImpl{}
+	for _, tc := range testCases {
+		got, err := spA.GetDatabaseDialect(ctx, &tc.acm, "testUri")
+		assert.Equal(t, tc.expectError, err != nil, tc.name)
+		assert.Equal(t, tc.want, got, tc.name)
+	}
+}
+
+func TestSpannerAccessorImpl_CreateEmptyDatabase(t *testing.T) {
+	testCases := []struct {
+		name        string
+		acm         spanneradmin.AdminClientMock
+		expectError bool
+		want        string
+	}{
+		{
+			name: "Basic",
+			acm: spanneradmin.AdminClientMock{
+				CreateDatabaseMock: func(ctx context.Context, req *databasepb.CreateDatabaseRequest, opts ...gax.CallOption) (spanneradmin.CreateDatabaseOperation, error) {
+					return &spanneradmin.CreateDatabaseOperationMock{
+						WaitMock: func(ctx context.Context, opts ...gax.CallOption) (*databasepb.Database, error) { return nil, nil },
+					}, nil
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "Create database returns error",
+			acm: spanneradmin.AdminClientMock{
+				CreateDatabaseMock: func(ctx context.Context, req *databasepb.CreateDatabaseRequest, opts ...gax.CallOption) (spanneradmin.CreateDatabaseOperation, error) {
+					return nil, fmt.Errorf("test error")
+				},
+			},
+			expectError: true,
+		},
+		{
+			name: "Wait returns error",
+			acm: spanneradmin.AdminClientMock{
+				CreateDatabaseMock: func(ctx context.Context, req *databasepb.CreateDatabaseRequest, opts ...gax.CallOption) (spanneradmin.CreateDatabaseOperation, error) {
+					return &spanneradmin.CreateDatabaseOperationMock{
+						WaitMock: func(ctx context.Context, opts ...gax.CallOption) (*databasepb.Database, error) {
+							return nil, fmt.Errorf("test error")
+						},
+					}, nil
+				},
+			},
+			expectError: true,
+		},
+	}
+	ctx := context.Background()
+	spA := SpannerAccessorImpl{}
+	for _, tc := range testCases {
+		err := spA.CreateEmptyDatabase(ctx, &tc.acm, "projects/test-project/instances/test-instance/databases/mydb")
+		assert.Equal(t, tc.expectError, err != nil, tc.name)
+	}
+}
+
+func TestSpannerAccessorImpl_CreateChangeStream(t *testing.T) {
+	testCases := []struct {
+		name        string
+		acm         spanneradmin.AdminClientMock
+		expectError bool
+		want        string
+	}{
+		{
+			name: "Basic",
+			acm: spanneradmin.AdminClientMock{
+				UpdateDatabaseDdlMock: func(ctx context.Context, req *databasepb.UpdateDatabaseDdlRequest, opts ...gax.CallOption) (spanneradmin.UpdateDatabaseDdlOperation, error) {
+					return &spanneradmin.UpdateDatabaseDdlOperationMock{
+						WaitMock: func(ctx context.Context, opts ...gax.CallOption) error { return nil },
+					}, nil
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "Update database ddl returns error",
+			acm: spanneradmin.AdminClientMock{
+				UpdateDatabaseDdlMock: func(ctx context.Context, req *databasepb.UpdateDatabaseDdlRequest, opts ...gax.CallOption) (spanneradmin.UpdateDatabaseDdlOperation, error) {
+					return nil, fmt.Errorf("test error")
+				},
+			},
+			expectError: true,
+		},
+		{
+			name: "Wait returns error",
+			acm: spanneradmin.AdminClientMock{
+				UpdateDatabaseDdlMock: func(ctx context.Context, req *databasepb.UpdateDatabaseDdlRequest, opts ...gax.CallOption) (spanneradmin.UpdateDatabaseDdlOperation, error) {
+					return &spanneradmin.UpdateDatabaseDdlOperationMock{
+						WaitMock: func(ctx context.Context, opts ...gax.CallOption) error {
+							return fmt.Errorf("test error")
+						},
+					}, nil
+				},
+			},
+			expectError: true,
+		},
+	}
+	ctx := context.Background()
+	spA := SpannerAccessorImpl{}
+	for _, tc := range testCases {
+		err := spA.CreateChangeStream(ctx, &tc.acm, "my-changestream", "projects/test-project/instances/test-instance/databases/mydb")
+		assert.Equal(t, tc.expectError, err != nil, tc.name)
+	}
+}

--- a/accessors/spanner/spanner_accessor_test.go
+++ b/accessors/spanner/spanner_accessor_test.go
@@ -1,0 +1,14 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package spanneraccessor

--- a/accessors/storage/mocks.go
+++ b/accessors/storage/mocks.go
@@ -1,0 +1,58 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package storageaccessor
+
+import (
+	"context"
+
+	storageclient "github.com/GoogleCloudPlatform/spanner-migration-tool/accessors/clients/storage"
+)
+
+type StorageAccessorMock struct {
+	CreateGCSBucketMock                 func(ctx context.Context, sc storageclient.StorageClient, bucketName, projectID, location string) error
+	CreateGCSBucketWithLifecycleMock    func(ctx context.Context, sc storageclient.StorageClient, bucketName, projectID, location string, matchesPrefix []string, ttl int64) error
+	EnableBucketLifecycleDeleteRuleMock func(ctx context.Context, sc storageclient.StorageClient, bucketName string, matchesPrefix []string, ttl int64) error
+	UploadLocalFileToGCSMock            func(ctx context.Context, sc storageclient.StorageClient, filePath, fileName, localFilePath string) error
+	WriteDataToGCSMock                  func(ctx context.Context, sc storageclient.StorageClient, filePath, fileName, data string) error
+	ReadGcsFileMock                     func(ctx context.Context, sc storageclient.StorageClient, filePath string) (string, error)
+	ReadAnyFileMock                     func(ctx context.Context, sc storageclient.StorageClient, filePath string) (string, error)
+}
+
+func (sam *StorageAccessorMock) CreateGCSBucket(ctx context.Context, sc storageclient.StorageClient, bucketName, projectID, location string) error {
+	return sam.CreateGCSBucketMock(ctx, sc, bucketName, projectID, location)
+}
+
+func (sam *StorageAccessorMock) CreateGCSBucketWithLifecycle(ctx context.Context, sc storageclient.StorageClient, bucketName, projectID, location string, matchesPrefix []string, ttl int64) error {
+	return sam.CreateGCSBucketWithLifecycleMock(ctx, sc, bucketName, projectID, location, matchesPrefix, ttl)
+}
+
+func (sam *StorageAccessorMock) EnableBucketLifecycleDeleteRule(ctx context.Context, sc storageclient.StorageClient, bucketName string, matchesPrefix []string, ttl int64) error {
+	return sam.EnableBucketLifecycleDeleteRuleMock(ctx, sc, bucketName, matchesPrefix, ttl)
+}
+
+func (sam *StorageAccessorMock) UploadLocalFileToGCS(ctx context.Context, sc storageclient.StorageClient, filePath, fileName, localFilePath string) error {
+	return sam.UploadLocalFileToGCSMock(ctx, sc, filePath, fileName, localFilePath)
+}
+
+func (sam *StorageAccessorMock) WriteDataToGCS(ctx context.Context, sc storageclient.StorageClient, filePath, fileName, data string) error {
+	return sam.WriteDataToGCSMock(ctx, sc, filePath, fileName, data)
+}
+
+func (sam *StorageAccessorMock) ReadGcsFile(ctx context.Context, sc storageclient.StorageClient, filePath string) (string, error) {
+	return sam.ReadGcsFileMock(ctx, sc, filePath)
+}
+
+func (sam *StorageAccessorMock) ReadAnyFile(ctx context.Context, sc storageclient.StorageClient, filePath string) (string, error) {
+	return sam.ReadAnyFileMock(ctx, sc, filePath)
+}

--- a/accessors/storage/mocks.go
+++ b/accessors/storage/mocks.go
@@ -19,6 +19,8 @@ import (
 	storageclient "github.com/GoogleCloudPlatform/spanner-migration-tool/accessors/clients/storage"
 )
 
+// Mock that implements the StorageAccessor interface.
+// Pass in unit tests where StorageAccessor is an input parameter.
 type StorageAccessorMock struct {
 	CreateGCSBucketMock                func(ctx context.Context, sc storageclient.StorageClient, bucketName, projectID, location string, ttl int64, matchesPrefix []string) error
 	ApplyBucketLifecycleDeleteRuleMock func(ctx context.Context, sc storageclient.StorageClient, bucketName string, matchesPrefix []string, ttl int64) error

--- a/accessors/storage/mocks.go
+++ b/accessors/storage/mocks.go
@@ -20,25 +20,20 @@ import (
 )
 
 type StorageAccessorMock struct {
-	CreateGCSBucketMock                 func(ctx context.Context, sc storageclient.StorageClient, bucketName, projectID, location string) error
-	CreateGCSBucketWithLifecycleMock    func(ctx context.Context, sc storageclient.StorageClient, bucketName, projectID, location string, matchesPrefix []string, ttl int64) error
-	EnableBucketLifecycleDeleteRuleMock func(ctx context.Context, sc storageclient.StorageClient, bucketName string, matchesPrefix []string, ttl int64) error
-	UploadLocalFileToGCSMock            func(ctx context.Context, sc storageclient.StorageClient, filePath, fileName, localFilePath string) error
-	WriteDataToGCSMock                  func(ctx context.Context, sc storageclient.StorageClient, filePath, fileName, data string) error
-	ReadGcsFileMock                     func(ctx context.Context, sc storageclient.StorageClient, filePath string) (string, error)
-	ReadAnyFileMock                     func(ctx context.Context, sc storageclient.StorageClient, filePath string) (string, error)
+	CreateGCSBucketMock                func(ctx context.Context, sc storageclient.StorageClient, bucketName, projectID, location string, ttl int64, matchesPrefix []string) error
+	ApplyBucketLifecycleDeleteRuleMock func(ctx context.Context, sc storageclient.StorageClient, bucketName string, matchesPrefix []string, ttl int64) error
+	UploadLocalFileToGCSMock           func(ctx context.Context, sc storageclient.StorageClient, filePath, fileName, localFilePath string) error
+	WriteDataToGCSMock                 func(ctx context.Context, sc storageclient.StorageClient, filePath, fileName, data string) error
+	ReadGcsFileMock                    func(ctx context.Context, sc storageclient.StorageClient, filePath string) (string, error)
+	ReadAnyFileMock                    func(ctx context.Context, sc storageclient.StorageClient, filePath string) (string, error)
 }
 
-func (sam *StorageAccessorMock) CreateGCSBucket(ctx context.Context, sc storageclient.StorageClient, bucketName, projectID, location string) error {
-	return sam.CreateGCSBucketMock(ctx, sc, bucketName, projectID, location)
+func (sam *StorageAccessorMock) CreateGCSBucket(ctx context.Context, sc storageclient.StorageClient, bucketName, projectID, location string, ttl int64, matchesPrefix []string) error {
+	return sam.CreateGCSBucketMock(ctx, sc, bucketName, projectID, location, ttl, matchesPrefix)
 }
 
-func (sam *StorageAccessorMock) CreateGCSBucketWithLifecycle(ctx context.Context, sc storageclient.StorageClient, bucketName, projectID, location string, matchesPrefix []string, ttl int64) error {
-	return sam.CreateGCSBucketWithLifecycleMock(ctx, sc, bucketName, projectID, location, matchesPrefix, ttl)
-}
-
-func (sam *StorageAccessorMock) EnableBucketLifecycleDeleteRule(ctx context.Context, sc storageclient.StorageClient, bucketName string, matchesPrefix []string, ttl int64) error {
-	return sam.EnableBucketLifecycleDeleteRuleMock(ctx, sc, bucketName, matchesPrefix, ttl)
+func (sam *StorageAccessorMock) ApplyBucketLifecycleDeleteRule(ctx context.Context, sc storageclient.StorageClient, bucketName string, matchesPrefix []string, ttl int64) error {
+	return sam.ApplyBucketLifecycleDeleteRuleMock(ctx, sc, bucketName, matchesPrefix, ttl)
 }
 
 func (sam *StorageAccessorMock) UploadLocalFileToGCS(ctx context.Context, sc storageclient.StorageClient, filePath, fileName, localFilePath string) error {

--- a/accessors/storage/mocks.go
+++ b/accessors/storage/mocks.go
@@ -22,20 +22,20 @@ import (
 // Mock that implements the StorageAccessor interface.
 // Pass in unit tests where StorageAccessor is an input parameter.
 type StorageAccessorMock struct {
-	CreateGCSBucketMock                func(ctx context.Context, sc storageclient.StorageClient, bucketName, projectID, location string, ttl int64, matchesPrefix []string) error
-	ApplyBucketLifecycleDeleteRuleMock func(ctx context.Context, sc storageclient.StorageClient, bucketName string, matchesPrefix []string, ttl int64) error
+	CreateGCSBucketMock                func(ctx context.Context, sc storageclient.StorageClient, req StorageBucketMetadata) error
+	ApplyBucketLifecycleDeleteRuleMock func(ctx context.Context, sc storageclient.StorageClient, req StorageBucketMetadata) error
 	UploadLocalFileToGCSMock           func(ctx context.Context, sc storageclient.StorageClient, filePath, fileName, localFilePath string) error
 	WriteDataToGCSMock                 func(ctx context.Context, sc storageclient.StorageClient, filePath, fileName, data string) error
 	ReadGcsFileMock                    func(ctx context.Context, sc storageclient.StorageClient, filePath string) (string, error)
 	ReadAnyFileMock                    func(ctx context.Context, sc storageclient.StorageClient, filePath string) (string, error)
 }
 
-func (sam *StorageAccessorMock) CreateGCSBucket(ctx context.Context, sc storageclient.StorageClient, bucketName, projectID, location string, ttl int64, matchesPrefix []string) error {
-	return sam.CreateGCSBucketMock(ctx, sc, bucketName, projectID, location, ttl, matchesPrefix)
+func (sam *StorageAccessorMock) CreateGCSBucket(ctx context.Context, sc storageclient.StorageClient, req StorageBucketMetadata) error {
+	return sam.CreateGCSBucketMock(ctx, sc, req)
 }
 
-func (sam *StorageAccessorMock) ApplyBucketLifecycleDeleteRule(ctx context.Context, sc storageclient.StorageClient, bucketName string, matchesPrefix []string, ttl int64) error {
-	return sam.ApplyBucketLifecycleDeleteRuleMock(ctx, sc, bucketName, matchesPrefix, ttl)
+func (sam *StorageAccessorMock) ApplyBucketLifecycleDeleteRule(ctx context.Context, sc storageclient.StorageClient, req StorageBucketMetadata) error {
+	return sam.ApplyBucketLifecycleDeleteRuleMock(ctx, sc, req)
 }
 
 func (sam *StorageAccessorMock) UploadLocalFileToGCS(ctx context.Context, sc storageclient.StorageClient, filePath, fileName, localFilePath string) error {

--- a/accessors/storage/storage_accessor.go
+++ b/accessors/storage/storage_accessor.go
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-package storageacc
+package storageaccessor
 
 import (
 	"context"

--- a/accessors/storage/storage_accessor.go
+++ b/accessors/storage/storage_accessor.go
@@ -114,7 +114,7 @@ func (sa *StorageAccessorImpl) ApplyBucketLifecycleDeleteRule(ctx context.Contex
 	return nil
 }
 
-// UploadLocalFileToGCS uploads an object.
+// UploadLocalFileToGCS uploads a local file at @localFilePath to a gcs file path @filePath with name @fileName.
 func (sa *StorageAccessorImpl) UploadLocalFileToGCS(ctx context.Context, sc storageclient.StorageClient, filePath, fileName, localFilePath string) error {
 	data, err := os.ReadFile(localFilePath)
 	if err != nil {
@@ -141,13 +141,13 @@ func (sa *StorageAccessorImpl) WriteDataToGCS(ctx context.Context, sc storagecli
 	logger.Log.Info(fmt.Sprintf("Writing data to %s", filePath))
 	n, err := fmt.Fprint(w, data)
 	if err != nil {
-		fmt.Printf("Failed to write to Cloud Storage: %s", filePath)
+		fmt.Printf("Failed to write to Cloud Storage: %s\n", filePath)
 		return err
 	}
 	logger.Log.Info(fmt.Sprintf("Wrote %d bytes to GCS", n))
 
 	if err := w.Close(); err != nil {
-		fmt.Printf("Failed to close GCS file: %s", filePath)
+		fmt.Printf("Failed to close GCS file: %s\n", filePath)
 		return err
 	}
 	return nil
@@ -162,7 +162,6 @@ func (sa *StorageAccessorImpl) ReadGcsFile(ctx context.Context, sc storageclient
 	bucketName := u.Host
 	bucket := sc.Bucket(bucketName)
 	obj := bucket.Object(u.Path[1:])
-
 	rc, err := obj.NewReader(ctx)
 	if err != nil {
 		return "", err

--- a/accessors/storage/storage_accessor.go
+++ b/accessors/storage/storage_accessor.go
@@ -40,15 +40,15 @@ type StorageAccessor interface {
 
 type StorageAccessorImpl struct{}
 
-func (sa StorageAccessorImpl) CreateGCSBucket(ctx context.Context, bucketName, projectID, location string) error {
+func (sa *StorageAccessorImpl) CreateGCSBucket(ctx context.Context, bucketName, projectID, location string) error {
 	return sa.createGCSBucketUtil(ctx, bucketName, projectID, location, nil, 0)
 }
 
-func (sa StorageAccessorImpl) CreateGCSBucketWithLifecycle(ctx context.Context, bucketName, projectID, location string, matchesPrefix []string, ttl int64) error {
+func (sa *StorageAccessorImpl) CreateGCSBucketWithLifecycle(ctx context.Context, bucketName, projectID, location string, matchesPrefix []string, ttl int64) error {
 	return sa.createGCSBucketUtil(ctx, bucketName, projectID, location, matchesPrefix, ttl)
 }
 
-func (sa StorageAccessorImpl) createGCSBucketUtil(ctx context.Context, bucketName, projectID, location string, matchesPrefix []string, ttl int64) error {
+func (sa *StorageAccessorImpl) createGCSBucketUtil(ctx context.Context, bucketName, projectID, location string, matchesPrefix []string, ttl int64) error {
 	client, err := storageclient.GetOrCreateClient(ctx)
 	if err != nil {
 		return err
@@ -95,7 +95,7 @@ func (sa StorageAccessorImpl) createGCSBucketUtil(ctx context.Context, bucketNam
 // Applies the bucket lifecycle with delete rule. Only accepts the Age and
 // prefix rule conditions as it is only used for the Datastream destination
 // bucket currently.
-func (sa StorageAccessorImpl) EnableBucketLifecycleDeleteRule(ctx context.Context, bucketName string, matchesPrefix []string, ttl int64) error {
+func (sa *StorageAccessorImpl) EnableBucketLifecycleDeleteRule(ctx context.Context, bucketName string, matchesPrefix []string, ttl int64) error {
 	client, err := storageclient.GetOrCreateClient(ctx)
 	if err != nil {
 		return fmt.Errorf("could not create client while enabling lifecycle: %w", err)
@@ -132,7 +132,7 @@ func (sa StorageAccessorImpl) EnableBucketLifecycleDeleteRule(ctx context.Contex
 }
 
 // UploadLocalFileToGCS uploads an object.
-func (sa StorageAccessorImpl) UploadLocalFileToGCS(ctx context.Context, filePath, fileName, localFilePath string) error {
+func (sa *StorageAccessorImpl) UploadLocalFileToGCS(ctx context.Context, filePath, fileName, localFilePath string) error {
 	data, err := os.ReadFile(localFilePath)
 	if err != nil {
 		return fmt.Errorf("could not read file %s: %w", localFilePath, err)
@@ -140,7 +140,7 @@ func (sa StorageAccessorImpl) UploadLocalFileToGCS(ctx context.Context, filePath
 	return sa.WriteDataToGCS(ctx, filePath, fileName, string(data))
 }
 
-func (sa StorageAccessorImpl) WriteDataToGCS(ctx context.Context, filePath, fileName, data string) error {
+func (sa *StorageAccessorImpl) WriteDataToGCS(ctx context.Context, filePath, fileName, data string) error {
 	client, err := storageclient.GetOrCreateClient(ctx)
 	if err != nil {
 		return fmt.Errorf("could not create client while uploading to GCS: %w", err)
@@ -170,7 +170,7 @@ func (sa StorageAccessorImpl) WriteDataToGCS(ctx context.Context, filePath, file
 	return nil
 }
 
-func (sa StorageAccessorImpl) ReadGcsFile(ctx context.Context, filePath string) (string, error) {
+func (sa *StorageAccessorImpl) ReadGcsFile(ctx context.Context, filePath string) (string, error) {
 	client, err := storageclient.GetOrCreateClient(ctx)
 	if err != nil {
 		return "", fmt.Errorf("could not create client: %w", err)
@@ -199,7 +199,7 @@ func (sa StorageAccessorImpl) ReadGcsFile(ctx context.Context, filePath string) 
 	return buf.String(), nil
 }
 
-func (sa StorageAccessorImpl) ReadAnyFile(ctx context.Context, filePath string) (string, error) {
+func (sa *StorageAccessorImpl) ReadAnyFile(ctx context.Context, filePath string) (string, error) {
 	if strings.HasPrefix(filePath, constants.GCS_FILE_PREFIX) {
 		return sa.ReadGcsFile(ctx, filePath)
 	}

--- a/accessors/storage/storage_accessor.go
+++ b/accessors/storage/storage_accessor.go
@@ -75,7 +75,7 @@ func createGCSBucketUtil(ctx context.Context, bucketName, projectID, location st
 		}
 
 	} else {
-		fmt.Printf("Created new GCS bucket: %v\n", bucketName)
+		logger.Log.Info(fmt.Sprintf("Created new GCS bucket: %v\n", bucketName))
 	}
 	return nil
 }
@@ -143,10 +143,14 @@ func WriteDataToGCS(ctx context.Context, filePath, fileName, data string) error 
 	obj := bucket.Object(u.Path[1:] + fileName)
 
 	w := obj.NewWriter(ctx)
-	if _, err := fmt.Fprint(w, data); err != nil {
+	logger.Log.Info(fmt.Sprintf("Writing data to %s", filePath))
+	n, err := fmt.Fprint(w, data)
+	if err != nil {
 		fmt.Printf("Failed to write to Cloud Storage: %s", filePath)
 		return err
 	}
+	logger.Log.Info(fmt.Sprintf("Wrote %d bytes to GCS", n))
+
 	if err := w.Close(); err != nil {
 		fmt.Printf("Failed to close GCS file: %s", filePath)
 		return err
@@ -174,9 +178,12 @@ func ReadGcsFile(ctx context.Context, filePath string) (string, error) {
 	}
 	defer rc.Close()
 	buf := new(strings.Builder)
-	if _, err := io.Copy(buf, rc); err != nil {
+	logger.Log.Info(fmt.Sprintf("Reading from %s", filePath))
+	n, err := io.Copy(buf, rc)
+	if err != nil {
 		return "", err
 	}
+	logger.Log.Info(fmt.Sprintf("Read %d bytes", n))
 	return buf.String(), nil
 }
 

--- a/accessors/storage/storage_accessor.go
+++ b/accessors/storage/storage_accessor.go
@@ -1,0 +1,192 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package storageacc
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"cloud.google.com/go/storage"
+	storageclient "github.com/GoogleCloudPlatform/spanner-migration-tool/accessors/clients/storage"
+	"github.com/GoogleCloudPlatform/spanner-migration-tool/common/constants"
+	"github.com/GoogleCloudPlatform/spanner-migration-tool/common/utils"
+	"github.com/GoogleCloudPlatform/spanner-migration-tool/logger"
+	"google.golang.org/api/googleapi"
+)
+
+func CreateGCSBucket(ctx context.Context, bucketName, projectID, location string) error {
+	return createGCSBucketUtil(ctx, bucketName, projectID, location, nil, 0)
+}
+
+func CreateGCSBucketWithLifecycle(ctx context.Context, bucketName, projectID, location string, matchesPrefix []string, ttl int64) error {
+	return createGCSBucketUtil(ctx, bucketName, projectID, location, matchesPrefix, ttl)
+}
+
+func createGCSBucketUtil(ctx context.Context, bucketName, projectID, location string, matchesPrefix []string, ttl int64) error {
+	client, err := storageclient.GetOrCreateClient(ctx)
+	if err != nil {
+		return err
+	}
+	bucket := client.Bucket(bucketName)
+	attrs := storage.BucketAttrs{
+		Location: location,
+	}
+	if ttl > 0 {
+		attrs.Lifecycle = storage.Lifecycle{
+			Rules: []storage.LifecycleRule{
+				{
+					Action: storage.LifecycleAction{Type: "Delete"},
+					Condition: storage.LifecycleCondition{
+						AgeInDays: ttl,
+						// The prefixes should not contain the bucket names and starting slash.
+						// For object gs://my_bucket/pictures/paris_2022.jpg,
+						// you would use a condition such as "matchesPrefix":["pictures/paris_"].
+						MatchesPrefix: matchesPrefix,
+					},
+				},
+			},
+		}
+	}
+
+	if err := bucket.Create(ctx, projectID, &attrs); err != nil {
+		if e, ok := err.(*googleapi.Error); ok {
+			// Ignoring the bucket already exists error.
+			if e.Code != 409 {
+				return fmt.Errorf("failed to create bucket: %v", err)
+			} else {
+				fmt.Printf("Using the existing bucket: %v \n", bucketName)
+			}
+		} else {
+			return fmt.Errorf("failed to create bucket: %v", err)
+		}
+
+	} else {
+		fmt.Printf("Created new GCS bucket: %v\n", bucketName)
+	}
+	return nil
+}
+
+// Applies the bucket lifecycle with delete rule. Only accepts the Age and
+// prefix rule conditions as it is only used for the Datastream destination
+// bucket currently.
+func EnableBucketLifecycleDeleteRule(ctx context.Context, bucketName string, matchesPrefix []string, ttl int64) error {
+	client, err := storageclient.GetOrCreateClient(ctx)
+	if err != nil {
+		return fmt.Errorf("could not create client while enabling lifecycle: %w", err)
+	}
+
+	for i, str := range matchesPrefix {
+		matchesPrefix[i] = strings.TrimPrefix(str, "/")
+	}
+	bucket := client.Bucket(bucketName)
+	bucketAttrsToUpdate := storage.BucketAttrsToUpdate{
+		Lifecycle: &storage.Lifecycle{
+			Rules: []storage.LifecycleRule{
+				{
+					Action: storage.LifecycleAction{Type: "Delete"},
+					Condition: storage.LifecycleCondition{
+						AgeInDays: ttl,
+						// The prefixes should not contain the bucket names and starting slash.
+						// For object gs://my_bucket/pictures/paris_2022.jpg,
+						// you would use a condition such as "matchesPrefix":["pictures/paris_"].
+						MatchesPrefix: matchesPrefix,
+					},
+				},
+			},
+		},
+	}
+
+	attrs, err := bucket.Update(ctx, bucketAttrsToUpdate)
+	if err != nil {
+		return fmt.Errorf("could not bucket with lifecycle: %w", err)
+	}
+	logger.Log.Info(fmt.Sprintf("Added lifecycle rule to bucket %v\n. Rule Action: %v\t Rule Condition: %v\n",
+		bucketName, attrs.Lifecycle.Rules[0].Action, attrs.Lifecycle.Rules[0].Condition))
+	return nil
+}
+
+// UploadLocalFileToGCS uploads an object.
+func UploadLocalFileToGCS(ctx context.Context, filePath, fileName, localFilePath string) error {
+	data, err := os.ReadFile(localFilePath)
+	if err != nil {
+		return fmt.Errorf("could not read file %s: %w", localFilePath, err)
+	}
+	return WriteDataToGCS(ctx, filePath, fileName, string(data))
+}
+
+func WriteDataToGCS(ctx context.Context, filePath, fileName, data string) error {
+	client, err := storageclient.GetOrCreateClient(ctx)
+	if err != nil {
+		return fmt.Errorf("could not create client while uploading to GCS: %w", err)
+	}
+
+	u, err := utils.ParseGCSFilePath(filePath)
+	if err != nil {
+		return fmt.Errorf("parseFilePath: unable to parse file path: %v", err)
+	}
+	bucketName := u.Host
+	bucket := client.Bucket(bucketName)
+	obj := bucket.Object(u.Path[1:] + fileName)
+
+	w := obj.NewWriter(ctx)
+	if _, err := fmt.Fprint(w, data); err != nil {
+		fmt.Printf("Failed to write to Cloud Storage: %s", filePath)
+		return err
+	}
+	if err := w.Close(); err != nil {
+		fmt.Printf("Failed to close GCS file: %s", filePath)
+		return err
+	}
+	return nil
+}
+
+func ReadGcsFile(ctx context.Context, filePath string) (string, error) {
+	client, err := storageclient.GetOrCreateClient(ctx)
+	if err != nil {
+		return "", fmt.Errorf("could not create client: %w", err)
+	}
+
+	u, err := utils.ParseGCSFilePath(filePath)
+	if err != nil {
+		return "", fmt.Errorf("unable to parse file path: %v", err)
+	}
+	bucketName := u.Host
+	bucket := client.Bucket(bucketName)
+	obj := bucket.Object(u.Path[1:])
+
+	rc, err := obj.NewReader(ctx)
+	if err != nil {
+		return "", err
+	}
+	defer rc.Close()
+	buf := new(strings.Builder)
+	if _, err := io.Copy(buf, rc); err != nil {
+		return "", err
+	}
+	return buf.String(), nil
+}
+
+func ReadAnyFile(ctx context.Context, filePath string) (string, error) {
+	if strings.HasPrefix(filePath, constants.GCS_FILE_PREFIX) {
+		return ReadGcsFile(ctx, filePath)
+	}
+	buf, err := os.ReadFile(filePath)
+	if err != nil {
+		return "", err
+	}
+	return string(buf), nil
+}

--- a/accessors/storage/storage_accessor_test.go
+++ b/accessors/storage/storage_accessor_test.go
@@ -1,0 +1,14 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package storageaccessor

--- a/accessors/storage/storage_accessor_test.go
+++ b/accessors/storage/storage_accessor_test.go
@@ -92,7 +92,13 @@ func TestStorageAccessorImpl_CreateGCSBucket(t *testing.T) {
 	ctx := context.Background()
 	sa := StorageAccessorImpl{}
 	for _, tc := range testCases {
-		err := sa.CreateGCSBucket(ctx, &tc.scm, "test-bucket", "test-project", "india2", 1, nil)
+		err := sa.CreateGCSBucket(ctx, &tc.scm, StorageBucketMetadata{
+			BucketName:    "test-bucket",
+			ProjectID:     "test-project",
+			Location:      "india2",
+			Ttl:           1,
+			MatchesPrefix: nil,
+		})
 		assert.Equal(t, tc.expectError, err != nil, tc.name)
 	}
 }
@@ -176,7 +182,11 @@ func TestStorageAccessorImpl_ApplyBucketLifecycleDeleteRule(t *testing.T) {
 	ctx := context.Background()
 	sa := StorageAccessorImpl{}
 	for _, tc := range testCases {
-		err := sa.ApplyBucketLifecycleDeleteRule(ctx, &tc.scm, "test-bucket", tc.matchesPrefix, tc.ttl)
+		err := sa.ApplyBucketLifecycleDeleteRule(ctx, &tc.scm, StorageBucketMetadata{
+			BucketName:    "test-bucket",
+			Ttl:           tc.ttl,
+			MatchesPrefix: tc.matchesPrefix,
+		})
 		assert.Equal(t, tc.expectError, err != nil, tc.name)
 	}
 }

--- a/accessors/storage/storage_accessor_test.go
+++ b/accessors/storage/storage_accessor_test.go
@@ -2,13 +2,384 @@
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//	http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// You may obtain a
 package storageaccessor
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"cloud.google.com/go/storage"
+	storageclient "github.com/GoogleCloudPlatform/spanner-migration-tool/accessors/clients/storage"
+	"github.com/GoogleCloudPlatform/spanner-migration-tool/logger"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+	"google.golang.org/api/googleapi"
+)
+
+func init() {
+	logger.Log = zap.NewNop()
+}
+
+func TestMain(m *testing.M) {
+	res := m.Run()
+	os.Exit(res)
+}
+
+func TestStorageAccessorImpl_CreateGCSBucket(t *testing.T) {
+	testCases := []struct {
+		name        string
+		scm         storageclient.StorageClientMock
+		expectError bool
+	}{
+		{
+			name: "Basic",
+			scm: storageclient.StorageClientMock{
+				BucketMock: func(name string) storageclient.BucketHandle {
+					return &storageclient.BucketHandleMock{
+						CreateMock: func(ctx context.Context, projectID string, attrs *storage.BucketAttrs) (err error) {
+							return nil
+						},
+					}
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "random error",
+			scm: storageclient.StorageClientMock{
+				BucketMock: func(name string) storageclient.BucketHandle {
+					return &storageclient.BucketHandleMock{
+						CreateMock: func(ctx context.Context, projectID string, attrs *storage.BucketAttrs) (err error) {
+							return fmt.Errorf("random error")
+						},
+					}
+				},
+			},
+			expectError: true,
+		},
+		{
+			name: "Bucket already exists",
+			scm: storageclient.StorageClientMock{
+				BucketMock: func(name string) storageclient.BucketHandle {
+					return &storageclient.BucketHandleMock{
+						CreateMock: func(ctx context.Context, projectID string, attrs *storage.BucketAttrs) (err error) {
+							return &googleapi.Error{Code: 409}
+						},
+					}
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "Other google api error",
+			scm: storageclient.StorageClientMock{
+				BucketMock: func(name string) storageclient.BucketHandle {
+					return &storageclient.BucketHandleMock{
+						CreateMock: func(ctx context.Context, projectID string, attrs *storage.BucketAttrs) (err error) {
+							return &googleapi.Error{Code: 100}
+						},
+					}
+				},
+			},
+			expectError: true,
+		},
+	}
+	ctx := context.Background()
+	sa := StorageAccessorImpl{}
+	for _, tc := range testCases {
+		err := sa.CreateGCSBucket(ctx, &tc.scm, "test-bucket", "test-project", "india2", 1, nil)
+		assert.Equal(t, tc.expectError, err != nil, tc.name)
+	}
+}
+
+func TestStorageAccessorImpl_ApplyBucketLifecycleDeleteRule(t *testing.T) {
+	testCases := []struct {
+		name          string
+		scm           storageclient.StorageClientMock
+		ttl           int64
+		matchesPrefix []string
+		expectError   bool
+	}{
+		{
+			name: "Basic",
+			scm: storageclient.StorageClientMock{
+				BucketMock: func(name string) storageclient.BucketHandle {
+					return &storageclient.BucketHandleMock{
+						UpdateMock: func(ctx context.Context, uattrs storage.BucketAttrsToUpdate) (attrs *storage.BucketAttrs, err error) {
+							if strings.HasPrefix(uattrs.Lifecycle.Rules[0].Condition.MatchesPrefix[0], "/") {
+								return nil, fmt.Errorf("test error")
+							}
+							return &storage.BucketAttrs{Lifecycle: storage.Lifecycle{Rules: []storage.LifecycleRule{
+								{
+									Action: storage.LifecycleAction{Type: "Delete"},
+									Condition: storage.LifecycleCondition{
+										AgeInDays:     5,
+										MatchesPrefix: []string{},
+									},
+								},
+							}}}, nil
+						},
+					}
+				},
+			},
+			ttl:           5,
+			matchesPrefix: []string{"test"},
+			expectError:   false,
+		},
+		{
+			name: "Update error",
+			scm: storageclient.StorageClientMock{
+				BucketMock: func(name string) storageclient.BucketHandle {
+					return &storageclient.BucketHandleMock{
+						UpdateMock: func(ctx context.Context, uattrs storage.BucketAttrsToUpdate) (attrs *storage.BucketAttrs, err error) {
+							return nil, fmt.Errorf("test error")
+						},
+					}
+				},
+			},
+			ttl:           5,
+			matchesPrefix: []string{"test"},
+			expectError:   true,
+		},
+		{
+			name: "Prefix '/' gets removed",
+			scm: storageclient.StorageClientMock{
+				BucketMock: func(name string) storageclient.BucketHandle {
+					return &storageclient.BucketHandleMock{
+						UpdateMock: func(ctx context.Context, uattrs storage.BucketAttrsToUpdate) (attrs *storage.BucketAttrs, err error) {
+							if strings.HasPrefix(uattrs.Lifecycle.Rules[0].Condition.MatchesPrefix[0], "/") {
+								return nil, fmt.Errorf("test error")
+							}
+							return &storage.BucketAttrs{Lifecycle: storage.Lifecycle{Rules: []storage.LifecycleRule{
+								{
+									Action: storage.LifecycleAction{Type: "Delete"},
+									Condition: storage.LifecycleCondition{
+										AgeInDays:     5,
+										MatchesPrefix: []string{},
+									},
+								},
+							}}}, nil
+						},
+					}
+				},
+			},
+			ttl:           5,
+			matchesPrefix: []string{"/test"},
+			expectError:   false,
+		},
+	}
+	ctx := context.Background()
+	sa := StorageAccessorImpl{}
+	for _, tc := range testCases {
+		err := sa.ApplyBucketLifecycleDeleteRule(ctx, &tc.scm, "test-bucket", tc.matchesPrefix, tc.ttl)
+		assert.Equal(t, tc.expectError, err != nil, tc.name)
+	}
+}
+
+func TestStorageAccessorImpl_WriteDataToGCS(t *testing.T) {
+	testCases := []struct {
+		name        string
+		scm         storageclient.StorageClientMock
+		filePath    string
+		fileName    string
+		data        string
+		expectError bool
+	}{
+		{
+			name: "Basic",
+			scm: storageclient.StorageClientMock{
+				BucketMock: func(name string) storageclient.BucketHandle {
+					return &storageclient.BucketHandleMock{
+						ObjectMock: func(name string) storageclient.ObjectHandle {
+							return &storageclient.ObjectHandleMock{
+								NewWriterMock: func(ctx context.Context) io.WriteCloser {
+									return &storageclient.WriterMock{
+										WriteMock: func(p []byte) (n int, err error) { return len(p), nil },
+										CloseMock: func() error { return nil },
+									}
+								},
+							}
+						},
+					}
+				},
+			},
+			filePath:    "gs://bucket/path",
+			fileName:    "test-file",
+			data:        "abcd",
+			expectError: false,
+		},
+		{
+			name: "File parsing error",
+			scm: storageclient.StorageClientMock{
+				BucketMock: func(name string) storageclient.BucketHandle {
+					return &storageclient.BucketHandleMock{
+						ObjectMock: func(name string) storageclient.ObjectHandle {
+							return &storageclient.ObjectHandleMock{
+								NewWriterMock: func(ctx context.Context) io.WriteCloser {
+									return &storageclient.WriterMock{
+										WriteMock: func(p []byte) (n int, err error) { return len(p), nil },
+										CloseMock: func() error { return nil },
+									}
+								},
+							}
+						},
+					}
+				},
+			},
+			filePath:    "://bucket/path",
+			fileName:    "test-file",
+			data:        "abcd",
+			expectError: true,
+		},
+		{
+			name: "Write error",
+			scm: storageclient.StorageClientMock{
+				BucketMock: func(name string) storageclient.BucketHandle {
+					return &storageclient.BucketHandleMock{
+						ObjectMock: func(name string) storageclient.ObjectHandle {
+							return &storageclient.ObjectHandleMock{
+								NewWriterMock: func(ctx context.Context) io.WriteCloser {
+									return &storageclient.WriterMock{
+										WriteMock: func(p []byte) (n int, err error) { return 0, fmt.Errorf("test-error") },
+										CloseMock: func() error { return nil },
+									}
+								},
+							}
+						},
+					}
+				},
+			},
+			filePath:    "gs://bucket/path",
+			fileName:    "test-file",
+			data:        "abcd",
+			expectError: true,
+		},
+		{
+			name: "Close error",
+			scm: storageclient.StorageClientMock{
+				BucketMock: func(name string) storageclient.BucketHandle {
+					return &storageclient.BucketHandleMock{
+						ObjectMock: func(name string) storageclient.ObjectHandle {
+							return &storageclient.ObjectHandleMock{
+								NewWriterMock: func(ctx context.Context) io.WriteCloser {
+									return &storageclient.WriterMock{
+										WriteMock: func(p []byte) (n int, err error) { return len(p), nil },
+										CloseMock: func() error { return fmt.Errorf("test error") },
+									}
+								},
+							}
+						},
+					}
+				},
+			},
+			filePath:    "gs://bucket/path",
+			fileName:    "test-file",
+			data:        "abcd",
+			expectError: true,
+		},
+	}
+	ctx := context.Background()
+	sa := StorageAccessorImpl{}
+	for _, tc := range testCases {
+		err := sa.WriteDataToGCS(ctx, &tc.scm, tc.filePath, tc.fileName, tc.data)
+		assert.Equal(t, tc.expectError, err != nil, tc.name)
+	}
+}
+
+func TestStorageAccessorImpl_ReadGcsFile(t *testing.T) {
+	testCases := []struct {
+		name        string
+		scm         storageclient.StorageClientMock
+		filePath    string
+		expectError bool
+		want        string
+	}{
+		{
+			name: "Basic",
+			scm: storageclient.StorageClientMock{
+				BucketMock: func(name string) storageclient.BucketHandle {
+					return &storageclient.BucketHandleMock{
+						ObjectMock: func(name string) storageclient.ObjectHandle {
+							return &storageclient.ObjectHandleMock{
+								NewReaderMock: func(ctx context.Context) (io.ReadCloser, error) {
+									return &storageclient.ReaderMock{
+										ReadMock: func(p []byte) (n int, err error) {
+											copy(p, "hello")
+											return 5, io.EOF
+										},
+										CloseMock: func() error { return nil },
+									}, nil
+								},
+							}
+						},
+					}
+				},
+			},
+			filePath:    "gs://bucket/path",
+			expectError: false,
+			want:        "hello",
+		},
+		{
+			name:        "Parse error",
+			scm:         storageclient.StorageClientMock{},
+			filePath:    "://bucket/path",
+			expectError: true,
+			want:        "",
+		},
+		{
+			name: "New reader error",
+			scm: storageclient.StorageClientMock{
+				BucketMock: func(name string) storageclient.BucketHandle {
+					return &storageclient.BucketHandleMock{
+						ObjectMock: func(name string) storageclient.ObjectHandle {
+							return &storageclient.ObjectHandleMock{
+								NewReaderMock: func(ctx context.Context) (io.ReadCloser, error) {
+									return nil, fmt.Errorf("test error")
+								},
+							}
+						},
+					}
+				},
+			},
+			filePath:    "gs://bucket/path",
+			expectError: true,
+			want:        "",
+		},
+		{
+			name: "Read error",
+			scm: storageclient.StorageClientMock{
+				BucketMock: func(name string) storageclient.BucketHandle {
+					return &storageclient.BucketHandleMock{
+						ObjectMock: func(name string) storageclient.ObjectHandle {
+							return &storageclient.ObjectHandleMock{
+								NewReaderMock: func(ctx context.Context) (io.ReadCloser, error) {
+									return &storageclient.ReaderMock{
+										ReadMock: func(p []byte) (n int, err error) {
+											return 0, fmt.Errorf("test error")
+										},
+										CloseMock: func() error { return nil },
+									}, nil
+								},
+							}
+						},
+					}
+				},
+			},
+			filePath:    "gs://bucket/path",
+			expectError: true,
+			want:        "",
+		},
+	}
+	ctx := context.Background()
+	sa := StorageAccessorImpl{}
+	for _, tc := range testCases {
+		got, err := sa.ReadGcsFile(ctx, &tc.scm, tc.filePath)
+		assert.Equal(t, tc.expectError, err != nil, tc.name)
+		assert.Equal(t, tc.want, got, tc.name)
+	}
+}

--- a/accessors/storage/types.go
+++ b/accessors/storage/types.go
@@ -1,0 +1,24 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package storageaccessor
+
+type StorageBucketMetadata struct {
+	BucketName string
+	// Not required for Updates.
+	ProjectID string
+	// Not required for Updates.
+	Location      string
+	Ttl           int64
+	MatchesPrefix []string
+}

--- a/accessors/utils/dataflow/dataflow_utils.go
+++ b/accessors/utils/dataflow/dataflow_utils.go
@@ -11,6 +11,9 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+// This is a package is kept with accessors because some functions import other accessors.
+// The common/utils package should not import any SMT dependency.
 package dataflowutils
 
 import (
@@ -21,8 +24,8 @@ import (
 	storageaccessor "github.com/GoogleCloudPlatform/spanner-migration-tool/accessors/storage"
 )
 
-func UnmarshalDataflowTuningConfig(ctx context.Context, filePath string) (dataflowaccessor.DataflowTuningConfig, error) {
-	jsonStr, err := storageaccessor.ReadAnyFile(ctx, filePath)
+func UnmarshalDataflowTuningConfig(ctx context.Context, sa storageaccessor.StorageAccessor, filePath string) (dataflowaccessor.DataflowTuningConfig, error) {
+	jsonStr, err := sa.ReadAnyFile(ctx, filePath)
 	if err != nil {
 		return dataflowaccessor.DataflowTuningConfig{}, err
 	}

--- a/accessors/utils/dataflow/dataflow_utils.go
+++ b/accessors/utils/dataflow/dataflow_utils.go
@@ -1,0 +1,35 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package dataflowutils
+
+import (
+	"context"
+	"encoding/json"
+
+	dataflowaccessor "github.com/GoogleCloudPlatform/spanner-migration-tool/accessors/dataflow"
+	storageaccessor "github.com/GoogleCloudPlatform/spanner-migration-tool/accessors/storage"
+)
+
+func UnmarshalDataflowTuningConfig(ctx context.Context, filePath string) (dataflowaccessor.DataflowTuningConfig, error) {
+	jsonStr, err := storageaccessor.ReadAnyFile(ctx, filePath)
+	if err != nil {
+		return dataflowaccessor.DataflowTuningConfig{}, err
+	}
+	tuningCfg := dataflowaccessor.DataflowTuningConfig{}
+	err = json.Unmarshal([]byte(jsonStr), &tuningCfg)
+	if err != nil {
+		return dataflowaccessor.DataflowTuningConfig{}, err
+	}
+	return tuningCfg, nil
+}

--- a/accessors/utils/dataflow/dataflow_utils.go
+++ b/accessors/utils/dataflow/dataflow_utils.go
@@ -20,12 +20,13 @@ import (
 	"context"
 	"encoding/json"
 
+	storageclient "github.com/GoogleCloudPlatform/spanner-migration-tool/accessors/clients/storage"
 	dataflowaccessor "github.com/GoogleCloudPlatform/spanner-migration-tool/accessors/dataflow"
 	storageaccessor "github.com/GoogleCloudPlatform/spanner-migration-tool/accessors/storage"
 )
 
-func UnmarshalDataflowTuningConfig(ctx context.Context, sa storageaccessor.StorageAccessor, filePath string) (dataflowaccessor.DataflowTuningConfig, error) {
-	jsonStr, err := sa.ReadAnyFile(ctx, filePath)
+func UnmarshalDataflowTuningConfig(ctx context.Context, sc storageclient.StorageClient, sa storageaccessor.StorageAccessor, filePath string) (dataflowaccessor.DataflowTuningConfig, error) {
+	jsonStr, err := sa.ReadAnyFile(ctx, sc, filePath)
 	if err != nil {
 		return dataflowaccessor.DataflowTuningConfig{}, err
 	}

--- a/accessors/utils/dataflow/dataflow_utils_test.go
+++ b/accessors/utils/dataflow/dataflow_utils_test.go
@@ -1,0 +1,144 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package dataflowutils
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	dataflowaccessor "github.com/GoogleCloudPlatform/spanner-migration-tool/accessors/dataflow"
+	storageaccessor "github.com/GoogleCloudPlatform/spanner-migration-tool/accessors/storage"
+	"github.com/GoogleCloudPlatform/spanner-migration-tool/logger"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+)
+
+func init() {
+	logger.Log = zap.NewNop()
+}
+
+func TestMain(m *testing.M) {
+	res := m.Run()
+	os.Exit(res)
+}
+
+type StorageAccessorMock struct {
+	storageaccessor.StorageAccessorImpl
+}
+
+var readAnyFileMock func(ctx context.Context, filePath string) (string, error)
+
+func (sam StorageAccessorMock) ReadAnyFile(ctx context.Context, filePath string) (string, error) {
+	return readAnyFileMock(ctx, filePath)
+}
+
+func TestUnmarshalDataflowTuningConfig(t *testing.T) {
+	testCases := []struct {
+		name            string
+		readAnyFileMock func(ctx context.Context, filePath string) (string, error)
+		expectError     bool
+		want            dataflowaccessor.DataflowTuningConfig
+	}{
+		{
+			name: "Basic",
+			readAnyFileMock: func(ctx context.Context, filePath string) (string, error) {
+				return `{
+					"projectId": "test-project",
+					"jobName": "test-job-name",
+					"location": "us-central1",
+					"network": "test-network",
+					"subnetwork": "test-subnetwork",
+					"hostProjectId": "test-host-project",
+					"maxWorkers": 3,
+					"numWorkers": 2,
+					"serviceAccountEmail": "abc@xyz.com",
+					"machineType": "n1-standard-8",
+					"additionalUserLabels": {"my": "label"},
+					"kmsKeyName": "test-key",
+					"gcsTemplatePath": "gs://path",
+					"additionalExperiments": ["xyz","123"],
+					"enableStreamingEngine": true
+				}`, nil
+			},
+			expectError: false,
+			want: dataflowaccessor.DataflowTuningConfig{
+				ProjectId:             "test-project",
+				JobName:               "test-job-name",
+				Location:              "us-central1",
+				Network:               "test-network",
+				Subnetwork:            "test-subnetwork",
+				VpcHostProjectId:      "test-host-project",
+				MaxWorkers:            3,
+				NumWorkers:            2,
+				ServiceAccountEmail:   "abc@xyz.com",
+				MachineType:           "n1-standard-8",
+				AdditionalUserLabels:  map[string]string{"my": "label"},
+				KmsKeyName:            "test-key",
+				GcsTemplatePath:       "gs://path",
+				AdditionalExperiments: []string{"xyz", "123"},
+				EnableStreamingEngine: true,
+			},
+		},
+		{
+			name: "Defaults",
+			readAnyFileMock: func(ctx context.Context, filePath string) (string, error) {
+				return `{}`, nil
+			},
+			expectError: false,
+			want: dataflowaccessor.DataflowTuningConfig{
+				ProjectId:             "",
+				JobName:               "",
+				Location:              "",
+				Network:               "",
+				Subnetwork:            "",
+				VpcHostProjectId:      "",
+				MaxWorkers:            0,
+				NumWorkers:            0,
+				ServiceAccountEmail:   "",
+				MachineType:           "",
+				AdditionalUserLabels:  nil,
+				KmsKeyName:            "",
+				GcsTemplatePath:       "",
+				AdditionalExperiments: nil,
+				EnableStreamingEngine: false,
+			},
+		},
+		{
+			name: "ReadAnyFile throws error",
+			readAnyFileMock: func(ctx context.Context, filePath string) (string, error) {
+				return "", fmt.Errorf("test error")
+			},
+			expectError: true,
+			want:        dataflowaccessor.DataflowTuningConfig{},
+		},
+		{
+			name: "Json unmarshall throws error",
+			readAnyFileMock: func(ctx context.Context, filePath string) (string, error) {
+				return "{\"abc\"", nil
+			},
+			expectError: true,
+			want:        dataflowaccessor.DataflowTuningConfig{},
+		},
+	}
+	ctx := context.Background()
+	saMock := StorageAccessorMock{}
+	for _, tc := range testCases {
+		readAnyFileMock = tc.readAnyFileMock
+		got, err := UnmarshalDataflowTuningConfig(ctx, &saMock, "unused/path/due/to/mock")
+		assert.Equal(t, tc.expectError, err != nil)
+		assert.Equal(t, tc.want, got)
+	}
+}

--- a/cmd/data.go
+++ b/cmd/data.go
@@ -26,6 +26,7 @@ import (
 
 	sp "cloud.google.com/go/spanner"
 	database "cloud.google.com/go/spanner/admin/database/apiv1"
+	spanneradmin "github.com/GoogleCloudPlatform/spanner-migration-tool/accessors/clients/spanner/admin"
 	spanneraccessor "github.com/GoogleCloudPlatform/spanner-migration-tool/accessors/spanner"
 	"github.com/GoogleCloudPlatform/spanner-migration-tool/common/constants"
 	"github.com/GoogleCloudPlatform/spanner-migration-tool/common/utils"
@@ -179,8 +180,12 @@ func (cmd *DataCmd) Execute(ctx context.Context, f *flag.FlagSet, _ ...interface
 
 // validateExistingDb validates that the existing spanner schema is in accordance with the one specified in the session file.
 func validateExistingDb(ctx context.Context, spDialect, dbURI string, adminClient *database.DatabaseAdminClient, client *sp.Client, conv *internal.Conv) error {
+	adminClientImpl, err := spanneradmin.NewAdminClientImpl(ctx)
+	if err != nil {
+		return err
+	}
 	spA := spanneraccessor.SpannerAccessorImpl{}
-	dbExists, err := spA.CheckExistingDb(ctx, dbURI)
+	dbExists, err := spA.CheckExistingDb(ctx, adminClientImpl, dbURI)
 	if err != nil {
 		err = fmt.Errorf("can't verify target database: %v", err)
 		return err

--- a/cmd/data.go
+++ b/cmd/data.go
@@ -26,6 +26,7 @@ import (
 
 	sp "cloud.google.com/go/spanner"
 	database "cloud.google.com/go/spanner/admin/database/apiv1"
+	spanneracc "github.com/GoogleCloudPlatform/spanner-migration-tool/accessors/spanner"
 	"github.com/GoogleCloudPlatform/spanner-migration-tool/common/constants"
 	"github.com/GoogleCloudPlatform/spanner-migration-tool/common/utils"
 	"github.com/GoogleCloudPlatform/spanner-migration-tool/conversion"
@@ -178,7 +179,7 @@ func (cmd *DataCmd) Execute(ctx context.Context, f *flag.FlagSet, _ ...interface
 
 // validateExistingDb validates that the existing spanner schema is in accordance with the one specified in the session file.
 func validateExistingDb(ctx context.Context, spDialect, dbURI string, adminClient *database.DatabaseAdminClient, client *sp.Client, conv *internal.Conv) error {
-	dbExists, err := conversion.CheckExistingDb(ctx, adminClient, dbURI)
+	dbExists, err := spanneracc.CheckExistingDb(ctx, dbURI)
 	if err != nil {
 		err = fmt.Errorf("can't verify target database: %v", err)
 		return err

--- a/cmd/data.go
+++ b/cmd/data.go
@@ -179,7 +179,8 @@ func (cmd *DataCmd) Execute(ctx context.Context, f *flag.FlagSet, _ ...interface
 
 // validateExistingDb validates that the existing spanner schema is in accordance with the one specified in the session file.
 func validateExistingDb(ctx context.Context, spDialect, dbURI string, adminClient *database.DatabaseAdminClient, client *sp.Client, conv *internal.Conv) error {
-	dbExists, err := spanneraccessor.CheckExistingDb(ctx, dbURI)
+	spA := spanneraccessor.SpannerAccessorImpl{}
+	dbExists, err := spA.CheckExistingDb(ctx, dbURI)
 	if err != nil {
 		err = fmt.Errorf("can't verify target database: %v", err)
 		return err

--- a/cmd/data.go
+++ b/cmd/data.go
@@ -26,7 +26,7 @@ import (
 
 	sp "cloud.google.com/go/spanner"
 	database "cloud.google.com/go/spanner/admin/database/apiv1"
-	spanneracc "github.com/GoogleCloudPlatform/spanner-migration-tool/accessors/spanner"
+	spanneraccessor "github.com/GoogleCloudPlatform/spanner-migration-tool/accessors/spanner"
 	"github.com/GoogleCloudPlatform/spanner-migration-tool/common/constants"
 	"github.com/GoogleCloudPlatform/spanner-migration-tool/common/utils"
 	"github.com/GoogleCloudPlatform/spanner-migration-tool/conversion"
@@ -179,7 +179,7 @@ func (cmd *DataCmd) Execute(ctx context.Context, f *flag.FlagSet, _ ...interface
 
 // validateExistingDb validates that the existing spanner schema is in accordance with the one specified in the session file.
 func validateExistingDb(ctx context.Context, spDialect, dbURI string, adminClient *database.DatabaseAdminClient, client *sp.Client, conv *internal.Conv) error {
-	dbExists, err := spanneracc.CheckExistingDb(ctx, dbURI)
+	dbExists, err := spanneraccessor.CheckExistingDb(ctx, dbURI)
 	if err != nil {
 		err = fmt.Errorf("can't verify target database: %v", err)
 		return err

--- a/common/constants/constants.go
+++ b/common/constants/constants.go
@@ -64,7 +64,8 @@ const (
 	MigrationMetadataKey string = "cloud-spanner-migration-metadata"
 
 	// Scheme used for GCS paths
-	GCS_SCHEME string = "gs"
+	GCS_SCHEME      string = "gs"
+	GCS_FILE_PREFIX string = "gs://"
 
 	// File upload prefix for dump and session load.
 	UPLOAD_FILE_DIR string = "upload-file"

--- a/common/utils/storage_utils.go
+++ b/common/utils/storage_utils.go
@@ -12,8 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package utils contains common helper functions used across multiple other packages.
-// Utils should not import any Spanner migration tool packages.
+/*
+Package utils contains common helper functions used across multiple other packages.
+Utils should not import any Spanner migration tool packages.
+*/
 package utils
 
 import (

--- a/common/utils/storage_utils.go
+++ b/common/utils/storage_utils.go
@@ -1,0 +1,41 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package utils contains common helper functions used across multiple other packages.
+// Utils should not import any Spanner migration tool packages.
+package utils
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/GoogleCloudPlatform/spanner-migration-tool/common/constants"
+)
+
+func ParseGCSFilePath(filePath string) (*url.URL, error) {
+	if len(filePath) == 0 {
+		return nil, fmt.Errorf("found empty GCS path")
+	}
+	if filePath[len(filePath)-1] != '/' {
+		filePath = filePath + "/"
+	}
+	u, err := url.Parse(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("parseFilePath: unable to parse file path %s", filePath)
+	}
+	if u.Scheme != constants.GCS_SCHEME {
+		return nil, fmt.Errorf("not a valid GCS path: %s, should start with 'gs'", filePath)
+	}
+	return u, nil
+}

--- a/common/utils/storage_utils_test.go
+++ b/common/utils/storage_utils_test.go
@@ -1,0 +1,87 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package utils
+
+import (
+	"net/url"
+	"os"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/spanner-migration-tool/logger"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+)
+
+func init() {
+	logger.Log = zap.NewNop()
+}
+
+func TestMain(m *testing.M) {
+	res := m.Run()
+	os.Exit(res)
+}
+
+func TestParseGCSFilePath(t *testing.T) {
+	testCases := []struct {
+		name        string
+		filePath    string
+		expectError bool
+		want        *url.URL
+	}{
+		{
+			name:        "Basic",
+			filePath:    "gs://test-bucket/path/to/folder/",
+			expectError: false,
+			want: &url.URL{
+				Scheme: "gs",
+				Host:   "test-bucket",
+				Path:   "/path/to/folder/",
+			},
+		},
+		{
+			name:        "Append Slash",
+			filePath:    "gs://test-bucket/path/to/folder",
+			expectError: false,
+			want: &url.URL{
+				Scheme: "gs",
+				Host:   "test-bucket",
+				Path:   "/path/to/folder/",
+			},
+		},
+		{
+			name:        "Empty File path",
+			filePath:    "",
+			expectError: true,
+			want:        nil,
+		},
+		{
+			name:        "Wrong Scheme",
+			filePath:    "ab://testpath",
+			expectError: true,
+			want:        nil,
+		},
+		{
+			name:        "Malformed Path",
+			filePath:    "://path",
+			expectError: true,
+			want:        nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		got, err := ParseGCSFilePath(tc.filePath)
+		assert.Equal(t, tc.expectError, err != nil)
+		assert.Equal(t, tc.want, got)
+	}
+}

--- a/common/utils/storage_utils_test.go
+++ b/common/utils/storage_utils_test.go
@@ -60,6 +60,26 @@ func TestParseGCSFilePath(t *testing.T) {
 			},
 		},
 		{
+			name:        "Empty path",
+			filePath:    "gs://test-bucket",
+			expectError: false,
+			want: &url.URL{
+				Scheme: "gs",
+				Host:   "test-bucket",
+				Path:   "/",
+			},
+		},
+		{
+			name:        "Empty path with leading slash",
+			filePath:    "gs://test-bucket/",
+			expectError: false,
+			want: &url.URL{
+				Scheme: "gs",
+				Host:   "test-bucket",
+				Path:   "/",
+			},
+		},
+		{
 			name:        "Empty File path",
 			filePath:    "",
 			expectError: true,
@@ -81,7 +101,7 @@ func TestParseGCSFilePath(t *testing.T) {
 
 	for _, tc := range testCases {
 		got, err := ParseGCSFilePath(tc.filePath)
-		assert.Equal(t, tc.expectError, err != nil)
-		assert.Equal(t, tc.want, got)
+		assert.Equal(t, tc.expectError, err != nil, tc.name)
+		assert.Equal(t, tc.want, got, tc.name)
 	}
 }

--- a/conversion/conversion.go
+++ b/conversion/conversion.go
@@ -802,7 +802,8 @@ func getSeekable(f *os.File) (*os.File, int64, error) {
 
 // VerifyDb checks whether the db exists and if it does, verifies if the schema is what we currently support.
 func VerifyDb(ctx context.Context, adminClient *database.DatabaseAdminClient, dbURI string) (dbExists bool, err error) {
-	dbExists, err = spanneraccessor.CheckExistingDb(ctx, dbURI)
+	spA := spanneraccessor.SpannerAccessorImpl{}
+	dbExists, err = spA.CheckExistingDb(ctx, dbURI)
 	if err != nil {
 		return dbExists, err
 	}

--- a/conversion/conversion.go
+++ b/conversion/conversion.go
@@ -356,8 +356,9 @@ func dataFromDatabase(ctx context.Context, sourceProfile profiles.SourceProfile,
 
 			// Try to apply lifecycle rule to Datastream destination bucket.
 			gcsConfig := streamingCfg.GcsCfg
+			sa := storageaccessor.StorageAccessorImpl{}
 			if gcsConfig.TtlInDaysSet {
-				err = storageaccessor.EnableBucketLifecycleDeleteRule(ctx, gcsBucket, []string{gcsDestPrefix}, gcsConfig.TtlInDays)
+				err = sa.EnableBucketLifecycleDeleteRule(ctx, gcsBucket, []string{gcsDestPrefix}, gcsConfig.TtlInDays)
 				if err != nil {
 					logger.Log.Warn(fmt.Sprintf("\nWARNING: could not update Datastream destination GCS bucket with lifecycle rule, error: %v\n", err))
 					logger.Log.Warn("Please apply the lifecycle rule manually. Continuing...\n")
@@ -477,8 +478,9 @@ func dataFromDatabaseForDataflowMigration(targetProfile profiles.TargetProfile, 
 
 		// Try to apply lifecycle rule to Datastream destination bucket.
 		gcsConfig := streamingCfg.GcsCfg
+		sa := storageaccessor.StorageAccessorImpl{}
 		if gcsConfig.TtlInDaysSet {
-			err = storageaccessor.EnableBucketLifecycleDeleteRule(ctx, gcsBucket, []string{gcsDestPrefix}, gcsConfig.TtlInDays)
+			err = sa.EnableBucketLifecycleDeleteRule(ctx, gcsBucket, []string{gcsDestPrefix}, gcsConfig.TtlInDays)
 			if err != nil {
 				logger.Log.Warn(fmt.Sprintf("\nWARNING: could not update Datastream destination GCS bucket with lifecycle rule, error: %v\n", err))
 				logger.Log.Warn("Please apply the lifecycle rule manually. Continuing...\n")

--- a/conversion/conversion.go
+++ b/conversion/conversion.go
@@ -363,7 +363,7 @@ func dataFromDatabase(ctx context.Context, sourceProfile profiles.SourceProfile,
 			}
 			sa := storageaccessor.StorageAccessorImpl{}
 			if gcsConfig.TtlInDaysSet {
-				err = sa.EnableBucketLifecycleDeleteRule(ctx, sc, gcsBucket, []string{gcsDestPrefix}, gcsConfig.TtlInDays)
+				err = sa.ApplyBucketLifecycleDeleteRule(ctx, sc, gcsBucket, []string{gcsDestPrefix}, gcsConfig.TtlInDays)
 				if err != nil {
 					logger.Log.Warn(fmt.Sprintf("\nWARNING: could not update Datastream destination GCS bucket with lifecycle rule, error: %v\n", err))
 					logger.Log.Warn("Please apply the lifecycle rule manually. Continuing...\n")
@@ -489,7 +489,7 @@ func dataFromDatabaseForDataflowMigration(targetProfile profiles.TargetProfile, 
 		}
 		sa := storageaccessor.StorageAccessorImpl{}
 		if gcsConfig.TtlInDaysSet {
-			err = sa.EnableBucketLifecycleDeleteRule(ctx, sc, gcsBucket, []string{gcsDestPrefix}, gcsConfig.TtlInDays)
+			err = sa.ApplyBucketLifecycleDeleteRule(ctx, sc, gcsBucket, []string{gcsDestPrefix}, gcsConfig.TtlInDays)
 			if err != nil {
 				logger.Log.Warn(fmt.Sprintf("\nWARNING: could not update Datastream destination GCS bucket with lifecycle rule, error: %v\n", err))
 				logger.Log.Warn("Please apply the lifecycle rule manually. Continuing...\n")

--- a/conversion/conversion.go
+++ b/conversion/conversion.go
@@ -364,7 +364,11 @@ func dataFromDatabase(ctx context.Context, sourceProfile profiles.SourceProfile,
 			}
 			sa := storageaccessor.StorageAccessorImpl{}
 			if gcsConfig.TtlInDaysSet {
-				err = sa.ApplyBucketLifecycleDeleteRule(ctx, sc, gcsBucket, []string{gcsDestPrefix}, gcsConfig.TtlInDays)
+				err = sa.ApplyBucketLifecycleDeleteRule(ctx, sc, storageaccessor.StorageBucketMetadata{
+					BucketName:    gcsBucket,
+					Ttl:           gcsConfig.TtlInDays,
+					MatchesPrefix: []string{gcsDestPrefix},
+				})
 				if err != nil {
 					logger.Log.Warn(fmt.Sprintf("\nWARNING: could not update Datastream destination GCS bucket with lifecycle rule, error: %v\n", err))
 					logger.Log.Warn("Please apply the lifecycle rule manually. Continuing...\n")
@@ -490,7 +494,11 @@ func dataFromDatabaseForDataflowMigration(targetProfile profiles.TargetProfile, 
 		}
 		sa := storageaccessor.StorageAccessorImpl{}
 		if gcsConfig.TtlInDaysSet {
-			err = sa.ApplyBucketLifecycleDeleteRule(ctx, sc, gcsBucket, []string{gcsDestPrefix}, gcsConfig.TtlInDays)
+			err = sa.ApplyBucketLifecycleDeleteRule(ctx, sc, storageaccessor.StorageBucketMetadata{
+				BucketName:    gcsBucket,
+				Ttl:           gcsConfig.TtlInDays,
+				MatchesPrefix: []string{gcsDestPrefix},
+			})
 			if err != nil {
 				logger.Log.Warn(fmt.Sprintf("\nWARNING: could not update Datastream destination GCS bucket with lifecycle rule, error: %v\n", err))
 				logger.Log.Warn("Please apply the lifecycle rule manually. Continuing...\n")

--- a/conversion/conversion.go
+++ b/conversion/conversion.go
@@ -44,6 +44,7 @@ import (
 	datastream "cloud.google.com/go/datastream/apiv1"
 	sp "cloud.google.com/go/spanner"
 	database "cloud.google.com/go/spanner/admin/database/apiv1"
+	spanneradmin "github.com/GoogleCloudPlatform/spanner-migration-tool/accessors/clients/spanner/admin"
 	storageclient "github.com/GoogleCloudPlatform/spanner-migration-tool/accessors/clients/storage"
 	spanneraccessor "github.com/GoogleCloudPlatform/spanner-migration-tool/accessors/spanner"
 	storageaccessor "github.com/GoogleCloudPlatform/spanner-migration-tool/accessors/storage"
@@ -811,8 +812,12 @@ func getSeekable(f *os.File) (*os.File, int64, error) {
 
 // VerifyDb checks whether the db exists and if it does, verifies if the schema is what we currently support.
 func VerifyDb(ctx context.Context, adminClient *database.DatabaseAdminClient, dbURI string) (dbExists bool, err error) {
+	adminClientImpl, err := spanneradmin.NewAdminClientImpl(ctx)
+	if err != nil {
+		return dbExists, err
+	}
 	spA := spanneraccessor.SpannerAccessorImpl{}
-	dbExists, err = spA.CheckExistingDb(ctx, dbURI)
+	dbExists, err = spA.CheckExistingDb(ctx, adminClientImpl, dbURI)
 	if err != nil {
 		return dbExists, err
 	}

--- a/streaming/streaming.go
+++ b/streaming/streaming.go
@@ -861,12 +861,12 @@ func StartDatastream(ctx context.Context, streamingCfg StreamingCfg, sourceProfi
 }
 
 func StartDataflow(ctx context.Context, targetProfile profiles.TargetProfile, streamingCfg StreamingCfg, conv *internal.Conv) (internal.DataflowOutput, error) {
-
+	sa := storageaccessor.StorageAccessorImpl{}
 	convJSON, err := json.MarshalIndent(conv, "", " ")
 	if err != nil {
 		return internal.DataflowOutput{}, fmt.Errorf("can't encode session state to JSON: %v", err)
 	}
-	err = storageaccessor.WriteDataToGCS(ctx, streamingCfg.TmpDir, "session.json", string(convJSON))
+	err = sa.WriteDataToGCS(ctx, streamingCfg.TmpDir, "session.json", string(convJSON))
 	if err != nil {
 		return internal.DataflowOutput{}, fmt.Errorf("error while writing to GCS: %v", err)
 	}
@@ -877,7 +877,7 @@ func StartDataflow(ctx context.Context, targetProfile profiles.TargetProfile, st
 	if err != nil {
 		return internal.DataflowOutput{}, fmt.Errorf("failed to compute transformation context: %s", err.Error())
 	}
-	err = storageaccessor.WriteDataToGCS(ctx, streamingCfg.TmpDir, "transformationContext.json", string(transformationContext))
+	err = sa.WriteDataToGCS(ctx, streamingCfg.TmpDir, "transformationContext.json", string(transformationContext))
 	if err != nil {
 		return internal.DataflowOutput{}, fmt.Errorf("error while writing to GCS: %v", err)
 	}

--- a/streaming/streaming.go
+++ b/streaming/streaming.go
@@ -34,7 +34,7 @@ import (
 	resourcemanager "cloud.google.com/go/resourcemanager/apiv3"
 	resourcemanagerpb "cloud.google.com/go/resourcemanager/apiv3/resourcemanagerpb"
 	dataflowaccessor "github.com/GoogleCloudPlatform/spanner-migration-tool/accessors/dataflow"
-	storageacc "github.com/GoogleCloudPlatform/spanner-migration-tool/accessors/storage"
+	storageaccessor "github.com/GoogleCloudPlatform/spanner-migration-tool/accessors/storage"
 	"github.com/GoogleCloudPlatform/spanner-migration-tool/common/constants"
 	"github.com/GoogleCloudPlatform/spanner-migration-tool/common/utils"
 	"github.com/GoogleCloudPlatform/spanner-migration-tool/internal"
@@ -866,7 +866,7 @@ func StartDataflow(ctx context.Context, targetProfile profiles.TargetProfile, st
 	if err != nil {
 		return internal.DataflowOutput{}, fmt.Errorf("can't encode session state to JSON: %v", err)
 	}
-	err = storageacc.WriteDataToGCS(ctx, streamingCfg.TmpDir, "session.json", string(convJSON))
+	err = storageaccessor.WriteDataToGCS(ctx, streamingCfg.TmpDir, "session.json", string(convJSON))
 	if err != nil {
 		return internal.DataflowOutput{}, fmt.Errorf("error while writing to GCS: %v", err)
 	}
@@ -877,7 +877,7 @@ func StartDataflow(ctx context.Context, targetProfile profiles.TargetProfile, st
 	if err != nil {
 		return internal.DataflowOutput{}, fmt.Errorf("failed to compute transformation context: %s", err.Error())
 	}
-	err = storageacc.WriteDataToGCS(ctx, streamingCfg.TmpDir, "transformationContext.json", string(transformationContext))
+	err = storageaccessor.WriteDataToGCS(ctx, streamingCfg.TmpDir, "transformationContext.json", string(transformationContext))
 	if err != nil {
 		return internal.DataflowOutput{}, fmt.Errorf("error while writing to GCS: %v", err)
 	}

--- a/streaming/streaming.go
+++ b/streaming/streaming.go
@@ -34,10 +34,12 @@ import (
 	resourcemanager "cloud.google.com/go/resourcemanager/apiv3"
 	resourcemanagerpb "cloud.google.com/go/resourcemanager/apiv3/resourcemanagerpb"
 	dataflowaccessor "github.com/GoogleCloudPlatform/spanner-migration-tool/accessors/dataflow"
+	storageacc "github.com/GoogleCloudPlatform/spanner-migration-tool/accessors/storage"
 	"github.com/GoogleCloudPlatform/spanner-migration-tool/common/constants"
 	"github.com/GoogleCloudPlatform/spanner-migration-tool/common/utils"
 	"github.com/GoogleCloudPlatform/spanner-migration-tool/internal"
 	"github.com/GoogleCloudPlatform/spanner-migration-tool/logger"
+
 	"github.com/GoogleCloudPlatform/spanner-migration-tool/profiles"
 	"github.com/google/uuid"
 	"github.com/googleapis/gax-go/v2"
@@ -864,7 +866,7 @@ func StartDataflow(ctx context.Context, targetProfile profiles.TargetProfile, st
 	if err != nil {
 		return internal.DataflowOutput{}, fmt.Errorf("can't encode session state to JSON: %v", err)
 	}
-	err = utils.WriteToGCS(streamingCfg.TmpDir, "session.json", string(convJSON))
+	err = storageacc.WriteDataToGCS(ctx, streamingCfg.TmpDir, "session.json", string(convJSON))
 	if err != nil {
 		return internal.DataflowOutput{}, fmt.Errorf("error while writing to GCS: %v", err)
 	}
@@ -875,7 +877,7 @@ func StartDataflow(ctx context.Context, targetProfile profiles.TargetProfile, st
 	if err != nil {
 		return internal.DataflowOutput{}, fmt.Errorf("failed to compute transformation context: %s", err.Error())
 	}
-	err = utils.WriteToGCS(streamingCfg.TmpDir, "transformationContext.json", string(transformationContext))
+	err = storageacc.WriteDataToGCS(ctx, streamingCfg.TmpDir, "transformationContext.json", string(transformationContext))
 	if err != nil {
 		return internal.DataflowOutput{}, fmt.Errorf("error while writing to GCS: %v", err)
 	}
@@ -884,44 +886,4 @@ func StartDataflow(ctx context.Context, targetProfile profiles.TargetProfile, st
 		return internal.DataflowOutput{}, fmt.Errorf("error launching dataflow: %v", err)
 	}
 	return dfOutput, nil
-}
-
-// Applies the bucket lifecycle with delete rule. Only accepts the Age and
-// prefix rule conditions as it is only used for the Datastream destination
-// bucket currently.
-func EnableBucketLifecycleDeleteRule(ctx context.Context, bucketName string, matchesPrefix []string, ttl int64) error {
-	client, err := storage.NewClient(ctx)
-	if err != nil {
-		return fmt.Errorf("could not create client while enabling lifecycle: %w", err)
-	}
-	defer client.Close()
-
-	for i, str := range matchesPrefix {
-		matchesPrefix[i] = strings.TrimPrefix(str, "/")
-	}
-	bucket := client.Bucket(bucketName)
-	bucketAttrsToUpdate := storage.BucketAttrsToUpdate{
-		Lifecycle: &storage.Lifecycle{
-			Rules: []storage.LifecycleRule{
-				{
-					Action: storage.LifecycleAction{Type: "Delete"},
-					Condition: storage.LifecycleCondition{
-						AgeInDays: ttl,
-						// The prefixes should not contain the bucket names and starting slash.
-						// For object gs://my_bucket/pictures/paris_2022.jpg,
-						// you would use a condition such as "matchesPrefix":["pictures/paris_"].
-						MatchesPrefix: matchesPrefix,
-					},
-				},
-			},
-		},
-	}
-
-	attrs, err := bucket.Update(ctx, bucketAttrsToUpdate)
-	if err != nil {
-		return fmt.Errorf("could not bucket with lifecycle: %w", err)
-	}
-	logger.Log.Info(fmt.Sprintf("Added lifecycle rule to bucket %v\n. Rule Action: %v\t Rule Condition: %v\n",
-		bucketName, attrs.Lifecycle.Rules[0].Action, attrs.Lifecycle.Rules[0].Condition))
-	return nil
 }

--- a/testing/accessors/spanner/spanner_accessor_test.go
+++ b/testing/accessors/spanner/spanner_accessor_test.go
@@ -45,6 +45,7 @@ var (
 	databaseAdmin *database.DatabaseAdminClient
 )
 
+// This test should move as a mock unit test inside accessors itself.
 func TestMain(m *testing.M) {
 	cleanup := initTests()
 	res := m.Run()

--- a/testing/accessors/spanner/spanner_accessor_test.go
+++ b/testing/accessors/spanner/spanner_accessor_test.go
@@ -15,7 +15,7 @@
 // TODO: Refactor this file and other integration tests by moving all common code
 // to remove redundancy.
 
-package utils_test
+package spanneraccessor_test
 
 import (
 	"context"
@@ -28,7 +28,7 @@ import (
 
 	database "cloud.google.com/go/spanner/admin/database/apiv1"
 	"cloud.google.com/go/spanner/admin/database/apiv1/databasepb"
-	spanneracc "github.com/GoogleCloudPlatform/spanner-migration-tool/accessors/spanner"
+	spanneraccessor "github.com/GoogleCloudPlatform/spanner-migration-tool/accessors/spanner"
 	"github.com/GoogleCloudPlatform/spanner-migration-tool/common/constants"
 	"github.com/GoogleCloudPlatform/spanner-migration-tool/conversion"
 	"github.com/GoogleCloudPlatform/spanner-migration-tool/internal"
@@ -116,7 +116,7 @@ func TestCheckExistingDb(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		dbExists, err := spanneracc.CheckExistingDb(ctx, fmt.Sprintf("projects/%s/instances/%s/databases/%s", projectID, instanceID, tc.dbName))
+		dbExists, err := spanneraccessor.CheckExistingDb(ctx, fmt.Sprintf("projects/%s/instances/%s/databases/%s", projectID, instanceID, tc.dbName))
 		assert.Nil(t, err)
 		assert.Equal(t, tc.dbExists, dbExists)
 	}

--- a/testing/accessors/spanner/spanner_accessor_test.go
+++ b/testing/accessors/spanner/spanner_accessor_test.go
@@ -28,6 +28,7 @@ import (
 
 	database "cloud.google.com/go/spanner/admin/database/apiv1"
 	"cloud.google.com/go/spanner/admin/database/apiv1/databasepb"
+	spanneradmin "github.com/GoogleCloudPlatform/spanner-migration-tool/accessors/clients/spanner/admin"
 	spanneraccessor "github.com/GoogleCloudPlatform/spanner-migration-tool/accessors/spanner"
 	"github.com/GoogleCloudPlatform/spanner-migration-tool/common/constants"
 	"github.com/GoogleCloudPlatform/spanner-migration-tool/conversion"
@@ -115,9 +116,13 @@ func TestCheckExistingDb(t *testing.T) {
 		{"check-db-exists", true},
 		{"check-db-does-not-exist", false},
 	}
+	adminClientImpl, err := spanneradmin.NewAdminClientImpl(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
 	spA := spanneraccessor.SpannerAccessorImpl{}
 	for _, tc := range testCases {
-		dbExists, err := spA.CheckExistingDb(ctx, fmt.Sprintf("projects/%s/instances/%s/databases/%s", projectID, instanceID, tc.dbName))
+		dbExists, err := spA.CheckExistingDb(ctx, adminClientImpl, fmt.Sprintf("projects/%s/instances/%s/databases/%s", projectID, instanceID, tc.dbName))
 		assert.Nil(t, err)
 		assert.Equal(t, tc.dbExists, dbExists)
 	}

--- a/testing/accessors/spanner/spanner_accessor_test.go
+++ b/testing/accessors/spanner/spanner_accessor_test.go
@@ -115,9 +115,9 @@ func TestCheckExistingDb(t *testing.T) {
 		{"check-db-exists", true},
 		{"check-db-does-not-exist", false},
 	}
-
+	spA := spanneraccessor.SpannerAccessorImpl{}
 	for _, tc := range testCases {
-		dbExists, err := spanneraccessor.CheckExistingDb(ctx, fmt.Sprintf("projects/%s/instances/%s/databases/%s", projectID, instanceID, tc.dbName))
+		dbExists, err := spA.CheckExistingDb(ctx, fmt.Sprintf("projects/%s/instances/%s/databases/%s", projectID, instanceID, tc.dbName))
 		assert.Nil(t, err)
 		assert.Equal(t, tc.dbExists, dbExists)
 	}

--- a/testing/accessors/spanner/spanner_accessor_test.go
+++ b/testing/accessors/spanner/spanner_accessor_test.go
@@ -1,0 +1,129 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// TODO: Refactor this file and other integration tests by moving all common code
+// to remove redundancy.
+
+package utils_test
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"testing"
+	"time"
+
+	database "cloud.google.com/go/spanner/admin/database/apiv1"
+	"cloud.google.com/go/spanner/admin/database/apiv1/databasepb"
+	spanneracc "github.com/GoogleCloudPlatform/spanner-migration-tool/accessors/spanner"
+	"github.com/GoogleCloudPlatform/spanner-migration-tool/common/constants"
+	"github.com/GoogleCloudPlatform/spanner-migration-tool/conversion"
+	"github.com/GoogleCloudPlatform/spanner-migration-tool/internal"
+	"github.com/GoogleCloudPlatform/spanner-migration-tool/logger"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+)
+
+var (
+	projectID  string
+	instanceID string
+
+	ctx           context.Context
+	databaseAdmin *database.DatabaseAdminClient
+)
+
+func TestMain(m *testing.M) {
+	cleanup := initTests()
+	res := m.Run()
+	cleanup()
+	os.Exit(res)
+}
+
+func init() {
+	logger.Log = zap.NewNop()
+}
+
+func initTests() (cleanup func()) {
+	projectID = os.Getenv("SPANNER_MIGRATION_TOOL_TESTS_GCLOUD_PROJECT_ID")
+	instanceID = os.Getenv("SPANNER_MIGRATION_TOOL_TESTS_GCLOUD_INSTANCE_ID")
+
+	ctx = context.Background()
+	flag.Parse() // Needed for testing.Short().
+	noop := func() {}
+
+	if testing.Short() {
+		log.Println("Unit test for UpdateDDLForeignKeys skipped in -short mode.")
+		return noop
+	}
+
+	if projectID == "" {
+		log.Println("Unit test for UpdateDDLForeignKeys skipped: SPANNER_MIGRATION_TOOL_TESTS_GCLOUD_PROJECT_ID is missing")
+		return noop
+	}
+
+	if instanceID == "" {
+		log.Println("Unit test for UpdateDDLForeignKeys skipped: SPANNER_MIGRATION_TOOL_TESTS_GCLOUD_INSTANCE_ID is missing")
+		return noop
+	}
+
+	var err error
+	databaseAdmin, err = database.NewDatabaseAdminClient(ctx)
+	if err != nil {
+		log.Fatalf("cannot create databaseAdmin client: %v", err)
+	}
+
+	return func() {
+		databaseAdmin.Close()
+	}
+}
+
+func dropDatabase(t *testing.T, dbPath string) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+	// Drop the testing database.
+	if err := databaseAdmin.DropDatabase(ctx, &databasepb.DropDatabaseRequest{Database: dbPath}); err != nil {
+		t.Fatalf("failed to drop testing database %v: %v", dbPath, err)
+	}
+}
+
+func TestCheckExistingDb(t *testing.T) {
+	onlyRunForEmulatorTest(t)
+	dbURI := fmt.Sprintf("projects/%s/instances/%s/databases/%s", projectID, instanceID, "check-db-exists")
+	err := conversion.CreateDatabase(ctx, databaseAdmin, dbURI, internal.MakeConv(), os.Stdout, "", constants.BULK_MIGRATION)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer dropDatabase(t, dbURI)
+	testCases := []struct {
+		dbName   string
+		dbExists bool
+	}{
+		{"check-db-exists", true},
+		{"check-db-does-not-exist", false},
+	}
+
+	for _, tc := range testCases {
+		dbExists, err := spanneracc.CheckExistingDb(ctx, fmt.Sprintf("projects/%s/instances/%s/databases/%s", projectID, instanceID, tc.dbName))
+		assert.Nil(t, err)
+		assert.Equal(t, tc.dbExists, dbExists)
+	}
+}
+
+func onlyRunForEmulatorTest(t *testing.T) {
+	if os.Getenv("SPANNER_EMULATOR_HOST") == "" {
+		t.Skip("Skipping tests only running against the emulator.")
+	}
+}

--- a/testing/conversion/conversion_test.go
+++ b/testing/conversion/conversion_test.go
@@ -248,29 +248,6 @@ func TestVerifyDb(t *testing.T) {
 	}
 }
 
-func TestCheckExistingDb(t *testing.T) {
-	onlyRunForEmulatorTest(t)
-	dbURI := fmt.Sprintf("projects/%s/instances/%s/databases/%s", projectID, instanceID, "check-db-exists")
-	err := conversion.CreateDatabase(ctx, databaseAdmin, dbURI, internal.MakeConv(), os.Stdout, "", constants.BULK_MIGRATION)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer dropDatabase(t, dbURI)
-	testCases := []struct {
-		dbName   string
-		dbExists bool
-	}{
-		{"check-db-exists", true},
-		{"check-db-does-not-exist", false},
-	}
-
-	for _, tc := range testCases {
-		dbExists, err := conversion.CheckExistingDb(ctx, databaseAdmin, fmt.Sprintf("projects/%s/instances/%s/databases/%s", projectID, instanceID, tc.dbName))
-		assert.Nil(t, err)
-		assert.Equal(t, tc.dbExists, dbExists)
-	}
-}
-
 func TestValidateDDL(t *testing.T) {
 	onlyRunForEmulatorTest(t)
 

--- a/webv2/helpers/helpers.go
+++ b/webv2/helpers/helpers.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	database "cloud.google.com/go/spanner/admin/database/apiv1"
+	spanneradmin "github.com/GoogleCloudPlatform/spanner-migration-tool/accessors/clients/spanner/admin"
 	spanneraccessor "github.com/GoogleCloudPlatform/spanner-migration-tool/accessors/spanner"
 	"github.com/GoogleCloudPlatform/spanner-migration-tool/common/constants"
 	adminpb "google.golang.org/genproto/googleapis/spanner/admin/database/v1"
@@ -153,15 +154,14 @@ func CheckOrCreateMetadataDb(projectId string, instanceId string) bool {
 	}
 
 	ctx := context.Background()
-	adminClient, err := database.NewDatabaseAdminClient(ctx)
+	adminClientImpl, err := spanneradmin.NewAdminClientImpl(ctx)
 	if err != nil {
 		fmt.Println(err)
 		return false
 	}
-	defer adminClient.Close()
 
 	spA := spanneraccessor.SpannerAccessorImpl{}
-	dbExists, err := spA.CheckExistingDb(ctx, uri)
+	dbExists, err := spA.CheckExistingDb(ctx, adminClientImpl, uri)
 	if err != nil {
 		fmt.Println(err)
 		return false

--- a/webv2/helpers/helpers.go
+++ b/webv2/helpers/helpers.go
@@ -21,8 +21,8 @@ import (
 	"strings"
 
 	database "cloud.google.com/go/spanner/admin/database/apiv1"
+	spanneracc "github.com/GoogleCloudPlatform/spanner-migration-tool/accessors/spanner"
 	"github.com/GoogleCloudPlatform/spanner-migration-tool/common/constants"
-	"github.com/GoogleCloudPlatform/spanner-migration-tool/conversion"
 	adminpb "google.golang.org/genproto/googleapis/spanner/admin/database/v1"
 )
 
@@ -160,7 +160,7 @@ func CheckOrCreateMetadataDb(projectId string, instanceId string) bool {
 	}
 	defer adminClient.Close()
 
-	dbExists, err := conversion.CheckExistingDb(ctx, adminClient, uri)
+	dbExists, err := spanneracc.CheckExistingDb(ctx, uri)
 	if err != nil {
 		fmt.Println(err)
 		return false

--- a/webv2/helpers/helpers.go
+++ b/webv2/helpers/helpers.go
@@ -21,7 +21,7 @@ import (
 	"strings"
 
 	database "cloud.google.com/go/spanner/admin/database/apiv1"
-	spanneracc "github.com/GoogleCloudPlatform/spanner-migration-tool/accessors/spanner"
+	spanneraccessor "github.com/GoogleCloudPlatform/spanner-migration-tool/accessors/spanner"
 	"github.com/GoogleCloudPlatform/spanner-migration-tool/common/constants"
 	adminpb "google.golang.org/genproto/googleapis/spanner/admin/database/v1"
 )
@@ -160,7 +160,7 @@ func CheckOrCreateMetadataDb(projectId string, instanceId string) bool {
 	}
 	defer adminClient.Close()
 
-	dbExists, err := spanneracc.CheckExistingDb(ctx, uri)
+	dbExists, err := spanneraccessor.CheckExistingDb(ctx, uri)
 	if err != nil {
 		fmt.Println(err)
 		return false

--- a/webv2/helpers/helpers.go
+++ b/webv2/helpers/helpers.go
@@ -160,7 +160,8 @@ func CheckOrCreateMetadataDb(projectId string, instanceId string) bool {
 	}
 	defer adminClient.Close()
 
-	dbExists, err := spanneraccessor.CheckExistingDb(ctx, uri)
+	spA := spanneraccessor.SpannerAccessorImpl{}
+	dbExists, err := spA.CheckExistingDb(ctx, uri)
 	if err != nil {
 		fmt.Println(err)
 		return false

--- a/webv2/profile/profile.go
+++ b/webv2/profile/profile.go
@@ -168,7 +168,13 @@ func CreateConnectionProfile(w http.ResponseWriter, r *http.Request) {
 		} else {
 			bucketName = strings.ToLower(sessionState.Conv.Audit.MigrationRequestId)
 		}
-		err = sa.CreateGCSBucket(ctx, sc, bucketName, sessionState.GCPProjectID, sessionState.Region, 0, nil)
+		err = sa.CreateGCSBucket(ctx, sc, storageaccessor.StorageBucketMetadata{
+			BucketName:    bucketName,
+			ProjectID:     sessionState.GCPProjectID,
+			Location:      sessionState.Region,
+			Ttl:           0,
+			MatchesPrefix: nil,
+		})
 		if err != nil {
 			http.Error(w, fmt.Sprintf("Error while creating bucket: %v", err), http.StatusBadRequest)
 			return

--- a/webv2/profile/profile.go
+++ b/webv2/profile/profile.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	datastream "cloud.google.com/go/datastream/apiv1"
+	storageacc "github.com/GoogleCloudPlatform/spanner-migration-tool/accessors/storage"
 	"github.com/GoogleCloudPlatform/spanner-migration-tool/common/constants"
 	"github.com/GoogleCloudPlatform/spanner-migration-tool/common/utils"
 	"github.com/GoogleCloudPlatform/spanner-migration-tool/streaming"
@@ -160,7 +161,7 @@ func CreateConnectionProfile(w http.ResponseWriter, r *http.Request) {
 		} else {
 			bucketName = strings.ToLower(sessionState.Conv.Audit.MigrationRequestId)
 		}
-		err = utils.CreateGCSBucket(bucketName, sessionState.GCPProjectID, sessionState.Region)
+		err = storageacc.CreateGCSBucket(ctx, bucketName, sessionState.GCPProjectID, sessionState.Region)
 		if err != nil {
 			http.Error(w, fmt.Sprintf("Error while creating bucket: %v", err), http.StatusBadRequest)
 			return

--- a/webv2/profile/profile.go
+++ b/webv2/profile/profile.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 
 	datastream "cloud.google.com/go/datastream/apiv1"
-	storageacc "github.com/GoogleCloudPlatform/spanner-migration-tool/accessors/storage"
+	storageaccessor "github.com/GoogleCloudPlatform/spanner-migration-tool/accessors/storage"
 	"github.com/GoogleCloudPlatform/spanner-migration-tool/common/constants"
 	"github.com/GoogleCloudPlatform/spanner-migration-tool/common/utils"
 	"github.com/GoogleCloudPlatform/spanner-migration-tool/streaming"
@@ -161,7 +161,7 @@ func CreateConnectionProfile(w http.ResponseWriter, r *http.Request) {
 		} else {
 			bucketName = strings.ToLower(sessionState.Conv.Audit.MigrationRequestId)
 		}
-		err = storageacc.CreateGCSBucket(ctx, bucketName, sessionState.GCPProjectID, sessionState.Region)
+		err = storageaccessor.CreateGCSBucket(ctx, bucketName, sessionState.GCPProjectID, sessionState.Region)
 		if err != nil {
 			http.Error(w, fmt.Sprintf("Error while creating bucket: %v", err), http.StatusBadRequest)
 			return

--- a/webv2/profile/profile.go
+++ b/webv2/profile/profile.go
@@ -168,7 +168,7 @@ func CreateConnectionProfile(w http.ResponseWriter, r *http.Request) {
 		} else {
 			bucketName = strings.ToLower(sessionState.Conv.Audit.MigrationRequestId)
 		}
-		err = sa.CreateGCSBucket(ctx, sc, bucketName, sessionState.GCPProjectID, sessionState.Region)
+		err = sa.CreateGCSBucket(ctx, sc, bucketName, sessionState.GCPProjectID, sessionState.Region, 0, nil)
 		if err != nil {
 			http.Error(w, fmt.Sprintf("Error while creating bucket: %v", err), http.StatusBadRequest)
 			return

--- a/webv2/profile/profile.go
+++ b/webv2/profile/profile.go
@@ -154,6 +154,7 @@ func CreateConnectionProfile(w http.ResponseWriter, r *http.Request) {
 		ValidateOnly: details.ValidateOnly,
 	}
 	var bucketName string
+	sa := storageaccessor.StorageAccessorImpl{}
 	if !details.IsSource {
 
 		if sessionState.IsSharded {
@@ -161,7 +162,7 @@ func CreateConnectionProfile(w http.ResponseWriter, r *http.Request) {
 		} else {
 			bucketName = strings.ToLower(sessionState.Conv.Audit.MigrationRequestId)
 		}
-		err = storageaccessor.CreateGCSBucket(ctx, bucketName, sessionState.GCPProjectID, sessionState.Region)
+		err = sa.CreateGCSBucket(ctx, bucketName, sessionState.GCPProjectID, sessionState.Region)
 		if err != nil {
 			http.Error(w, fmt.Sprintf("Error while creating bucket: %v", err), http.StatusBadRequest)
 			return

--- a/webv2/profile/profile.go
+++ b/webv2/profile/profile.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	datastream "cloud.google.com/go/datastream/apiv1"
+	storageclient "github.com/GoogleCloudPlatform/spanner-migration-tool/accessors/clients/storage"
 	storageaccessor "github.com/GoogleCloudPlatform/spanner-migration-tool/accessors/storage"
 	"github.com/GoogleCloudPlatform/spanner-migration-tool/common/constants"
 	"github.com/GoogleCloudPlatform/spanner-migration-tool/common/utils"
@@ -154,6 +155,11 @@ func CreateConnectionProfile(w http.ResponseWriter, r *http.Request) {
 		ValidateOnly: details.ValidateOnly,
 	}
 	var bucketName string
+	sc, err := storageclient.NewStorageClientImpl(ctx)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("Error while StorageClientImpl: %v", err), http.StatusBadRequest)
+		return
+	}
 	sa := storageaccessor.StorageAccessorImpl{}
 	if !details.IsSource {
 
@@ -162,7 +168,7 @@ func CreateConnectionProfile(w http.ResponseWriter, r *http.Request) {
 		} else {
 			bucketName = strings.ToLower(sessionState.Conv.Audit.MigrationRequestId)
 		}
-		err = sa.CreateGCSBucket(ctx, bucketName, sessionState.GCPProjectID, sessionState.Region)
+		err = sa.CreateGCSBucket(ctx, sc, bucketName, sessionState.GCPProjectID, sessionState.Region)
 		if err != nil {
 			http.Error(w, fmt.Sprintf("Error while creating bucket: %v", err), http.StatusBadRequest)
 			return

--- a/webv2/session/session_service.go
+++ b/webv2/session/session_service.go
@@ -87,8 +87,9 @@ func migrateMetadataDb(projectId, instanceId string) {
 	}
 	defer adminClient.Close()
 
+	spA := spanneraccessor.SpannerAccessorImpl{}
 	oldMetadataDbUri := getOldMetadataDbUri(projectId, instanceId)
-	oldMetadataDBExists, err := spanneraccessor.CheckExistingDb(ctx, oldMetadataDbUri)
+	oldMetadataDBExists, err := spA.CheckExistingDb(ctx, oldMetadataDbUri)
 	if err != nil {
 		fmt.Printf("could not check if oldMetadataDB exists. error=%v\n", err)
 		return

--- a/webv2/session/session_service.go
+++ b/webv2/session/session_service.go
@@ -7,7 +7,7 @@ import (
 	"cloud.google.com/go/spanner"
 	database "cloud.google.com/go/spanner/admin/database/apiv1"
 	"cloud.google.com/go/spanner/admin/database/apiv1/databasepb"
-	"github.com/GoogleCloudPlatform/spanner-migration-tool/conversion"
+	spanneracc "github.com/GoogleCloudPlatform/spanner-migration-tool/accessors/spanner"
 	helpers "github.com/GoogleCloudPlatform/spanner-migration-tool/webv2/helpers"
 )
 
@@ -88,7 +88,7 @@ func migrateMetadataDb(projectId, instanceId string) {
 	defer adminClient.Close()
 
 	oldMetadataDbUri := getOldMetadataDbUri(projectId, instanceId)
-	oldMetadataDBExists, err := conversion.CheckExistingDb(ctx, adminClient, oldMetadataDbUri)
+	oldMetadataDBExists, err := spanneracc.CheckExistingDb(ctx, oldMetadataDbUri)
 	if err != nil {
 		fmt.Printf("could not check if oldMetadataDB exists. error=%v\n", err)
 		return

--- a/webv2/session/session_service.go
+++ b/webv2/session/session_service.go
@@ -7,7 +7,7 @@ import (
 	"cloud.google.com/go/spanner"
 	database "cloud.google.com/go/spanner/admin/database/apiv1"
 	"cloud.google.com/go/spanner/admin/database/apiv1/databasepb"
-	spanneracc "github.com/GoogleCloudPlatform/spanner-migration-tool/accessors/spanner"
+	spanneraccessor "github.com/GoogleCloudPlatform/spanner-migration-tool/accessors/spanner"
 	helpers "github.com/GoogleCloudPlatform/spanner-migration-tool/webv2/helpers"
 )
 
@@ -88,7 +88,7 @@ func migrateMetadataDb(projectId, instanceId string) {
 	defer adminClient.Close()
 
 	oldMetadataDbUri := getOldMetadataDbUri(projectId, instanceId)
-	oldMetadataDBExists, err := spanneracc.CheckExistingDb(ctx, oldMetadataDbUri)
+	oldMetadataDBExists, err := spanneraccessor.CheckExistingDb(ctx, oldMetadataDbUri)
 	if err != nil {
 		fmt.Printf("could not check if oldMetadataDB exists. error=%v\n", err)
 		return

--- a/webv2/session/session_service.go
+++ b/webv2/session/session_service.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 
 	"cloud.google.com/go/spanner"
-	database "cloud.google.com/go/spanner/admin/database/apiv1"
 	"cloud.google.com/go/spanner/admin/database/apiv1/databasepb"
+	spanneradmin "github.com/GoogleCloudPlatform/spanner-migration-tool/accessors/clients/spanner/admin"
 	spanneraccessor "github.com/GoogleCloudPlatform/spanner-migration-tool/accessors/spanner"
 	helpers "github.com/GoogleCloudPlatform/spanner-migration-tool/webv2/helpers"
 )
@@ -80,16 +80,15 @@ func getOldMetadataDbUri(projectId string, instanceId string) string {
 
 func migrateMetadataDb(projectId, instanceId string) {
 	ctx := context.Background()
-	adminClient, err := database.NewDatabaseAdminClient(ctx)
+	adminClientImpl, err := spanneradmin.NewAdminClientImpl(ctx)
 	if err != nil {
 		fmt.Println(err)
 		return
 	}
-	defer adminClient.Close()
 
 	spA := spanneraccessor.SpannerAccessorImpl{}
 	oldMetadataDbUri := getOldMetadataDbUri(projectId, instanceId)
-	oldMetadataDBExists, err := spA.CheckExistingDb(ctx, oldMetadataDbUri)
+	oldMetadataDBExists, err := spA.CheckExistingDb(ctx, adminClientImpl, oldMetadataDbUri)
 	if err != nil {
 		fmt.Printf("could not check if oldMetadataDB exists. error=%v\n", err)
 		return

--- a/webv2/session/session_service.go
+++ b/webv2/session/session_service.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"cloud.google.com/go/spanner"
+	database "cloud.google.com/go/spanner/admin/database/apiv1"
 	"cloud.google.com/go/spanner/admin/database/apiv1/databasepb"
 	spanneradmin "github.com/GoogleCloudPlatform/spanner-migration-tool/accessors/clients/spanner/admin"
 	spanneraccessor "github.com/GoogleCloudPlatform/spanner-migration-tool/accessors/spanner"
@@ -157,7 +158,12 @@ func migrateMetadataDb(projectId, instanceId string) {
 	}
 
 	fmt.Println("Successfully wrote data to new metadata DB.")
-
+	adminClient, err := database.NewDatabaseAdminClient(ctx)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	defer adminClient.Close()
 	err = adminClient.DropDatabase(ctx, &databasepb.DropDatabaseRequest{
 		Database: oldMetadataDbUri,
 	})

--- a/webv2/web.go
+++ b/webv2/web.go
@@ -2486,8 +2486,8 @@ func createConfigFileForShardedBulkMigration(sessionState *session.SessionState,
 }
 
 func writeSessionFile(ctx context.Context, sessionState *session.SessionState) error {
-
-	err := storageaccessor.CreateGCSBucket(ctx, sessionState.Bucket, sessionState.GCPProjectID, sessionState.Region)
+	sa := storageaccessor.StorageAccessorImpl{}
+	err := sa.CreateGCSBucket(ctx, sessionState.Bucket, sessionState.GCPProjectID, sessionState.Region)
 	if err != nil {
 		return fmt.Errorf("error while creating bucket: %v", err)
 	}
@@ -2496,7 +2496,7 @@ func writeSessionFile(ctx context.Context, sessionState *session.SessionState) e
 	if err != nil {
 		return fmt.Errorf("can't encode session state to JSON: %v", err)
 	}
-	err = storageaccessor.WriteDataToGCS(ctx, "gs://"+sessionState.Bucket+sessionState.RootPath, "session.json", string(convJSON))
+	err = sa.WriteDataToGCS(ctx, "gs://"+sessionState.Bucket+sessionState.RootPath, "session.json", string(convJSON))
 	if err != nil {
 		return fmt.Errorf("error while writing to GCS: %v", err)
 	}

--- a/webv2/web.go
+++ b/webv2/web.go
@@ -2492,7 +2492,7 @@ func writeSessionFile(ctx context.Context, sessionState *session.SessionState) e
 		return err
 	}
 	sa := storageaccessor.StorageAccessorImpl{}
-	err = sa.CreateGCSBucket(ctx, sc, sessionState.Bucket, sessionState.GCPProjectID, sessionState.Region)
+	err = sa.CreateGCSBucket(ctx, sc, sessionState.Bucket, sessionState.GCPProjectID, sessionState.Region, 0, nil)
 	if err != nil {
 		return fmt.Errorf("error while creating bucket: %v", err)
 	}

--- a/webv2/web.go
+++ b/webv2/web.go
@@ -36,7 +36,7 @@ import (
 	"time"
 
 	instance "cloud.google.com/go/spanner/admin/instance/apiv1"
-	storageacc "github.com/GoogleCloudPlatform/spanner-migration-tool/accessors/storage"
+	storageaccessor "github.com/GoogleCloudPlatform/spanner-migration-tool/accessors/storage"
 	"github.com/GoogleCloudPlatform/spanner-migration-tool/cmd"
 	"github.com/GoogleCloudPlatform/spanner-migration-tool/common/constants"
 	"github.com/GoogleCloudPlatform/spanner-migration-tool/common/utils"
@@ -2487,7 +2487,7 @@ func createConfigFileForShardedBulkMigration(sessionState *session.SessionState,
 
 func writeSessionFile(ctx context.Context, sessionState *session.SessionState) error {
 
-	err := storageacc.CreateGCSBucket(ctx, sessionState.Bucket, sessionState.GCPProjectID, sessionState.Region)
+	err := storageaccessor.CreateGCSBucket(ctx, sessionState.Bucket, sessionState.GCPProjectID, sessionState.Region)
 	if err != nil {
 		return fmt.Errorf("error while creating bucket: %v", err)
 	}
@@ -2496,7 +2496,7 @@ func writeSessionFile(ctx context.Context, sessionState *session.SessionState) e
 	if err != nil {
 		return fmt.Errorf("can't encode session state to JSON: %v", err)
 	}
-	err = storageacc.WriteDataToGCS(ctx, "gs://"+sessionState.Bucket+sessionState.RootPath, "session.json", string(convJSON))
+	err = storageaccessor.WriteDataToGCS(ctx, "gs://"+sessionState.Bucket+sessionState.RootPath, "session.json", string(convJSON))
 	if err != nil {
 		return fmt.Errorf("error while writing to GCS: %v", err)
 	}

--- a/webv2/web.go
+++ b/webv2/web.go
@@ -2492,7 +2492,13 @@ func writeSessionFile(ctx context.Context, sessionState *session.SessionState) e
 		return err
 	}
 	sa := storageaccessor.StorageAccessorImpl{}
-	err = sa.CreateGCSBucket(ctx, sc, sessionState.Bucket, sessionState.GCPProjectID, sessionState.Region, 0, nil)
+	err = sa.CreateGCSBucket(ctx, sc, storageaccessor.StorageBucketMetadata{
+		BucketName:    sessionState.Bucket,
+		ProjectID:     sessionState.GCPProjectID,
+		Location:      sessionState.Region,
+		Ttl:           0,
+		MatchesPrefix: nil,
+	})
 	if err != nil {
 		return fmt.Errorf("error while creating bucket: %v", err)
 	}

--- a/webv2/web.go
+++ b/webv2/web.go
@@ -36,6 +36,7 @@ import (
 	"time"
 
 	instance "cloud.google.com/go/spanner/admin/instance/apiv1"
+	storageacc "github.com/GoogleCloudPlatform/spanner-migration-tool/accessors/storage"
 	"github.com/GoogleCloudPlatform/spanner-migration-tool/cmd"
 	"github.com/GoogleCloudPlatform/spanner-migration-tool/common/constants"
 	"github.com/GoogleCloudPlatform/spanner-migration-tool/common/utils"
@@ -2263,7 +2264,7 @@ func migrate(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, fmt.Sprintf("Can't get source and target profiles: %v", err), http.StatusBadRequest)
 		return
 	}
-	err = writeSessionFile(sessionState)
+	err = writeSessionFile(ctx, sessionState)
 	if err != nil {
 		log.Println("can't write session file")
 		http.Error(w, fmt.Sprintf("Can't write session file to GCS: %v", err), http.StatusBadRequest)
@@ -2484,9 +2485,9 @@ func createConfigFileForShardedBulkMigration(sessionState *session.SessionState,
 	return nil
 }
 
-func writeSessionFile(sessionState *session.SessionState) error {
+func writeSessionFile(ctx context.Context, sessionState *session.SessionState) error {
 
-	err := utils.CreateGCSBucket(sessionState.Bucket, sessionState.GCPProjectID, sessionState.Region)
+	err := storageacc.CreateGCSBucket(ctx, sessionState.Bucket, sessionState.GCPProjectID, sessionState.Region)
 	if err != nil {
 		return fmt.Errorf("error while creating bucket: %v", err)
 	}
@@ -2495,7 +2496,7 @@ func writeSessionFile(sessionState *session.SessionState) error {
 	if err != nil {
 		return fmt.Errorf("can't encode session state to JSON: %v", err)
 	}
-	err = utils.WriteToGCS("gs://"+sessionState.Bucket+sessionState.RootPath, "session.json", string(convJSON))
+	err = storageacc.WriteDataToGCS(ctx, "gs://"+sessionState.Bucket+sessionState.RootPath, "session.json", string(convJSON))
 	if err != nil {
 		return fmt.Errorf("error while writing to GCS: %v", err)
 	}
@@ -3031,7 +3032,7 @@ type ResourceDetails struct {
 	ResourceType string `json:"ResourceType"`
 	ResourceName string `json:"ResourceName"`
 	ResourceUrl  string `json:"ResourceUrl"`
-	GcloudCmd string `json:"GcloudCmd"`
+	GcloudCmd    string `json:"GcloudCmd"`
 }
 type GeneratedResources struct {
 	MigrationJobId string `json:"MigrationJobId"`
@@ -3054,7 +3055,7 @@ type GeneratedResources struct {
 	AggMonitoringDashboardName string `json:"AggMonitoringDashboardName"`
 	AggMonitoringDashboardUrl  string `json:"AggMonitoringDashboardUrl"`
 	//Used for sharded migration flow
-	ShardToShardResourcesMap	  map[string][]ResourceDetails `json:"ShardToShardResourcesMap"`
+	ShardToShardResourcesMap map[string][]ResourceDetails `json:"ShardToShardResourcesMap"`
 }
 
 func addTypeToList(convertedType string, spType string, issues []internal.SchemaIssue, l []typeIssue) []typeIssue {


### PR DESCRIPTION
This PR adds accessors, clients and mocks for some of the resource classes used by Reverse Replication. 
The accessor classes contains methods that internally use these resource clients (ex: adminClient.CreateDatabase()). Moving forward, all resource client calls should be made via accessors, no resource client method should be called directly.
- The `accessors/client/<resource>/` contains interface and mock definitions for the corresponding <resource> client.
- The `accessors/<resource>/` contains interface and mock definitions for the corresponding <resource> accessors.

For unit testing purposes, the accessor implementors are created just before the call wherever refactoring is done [Example](https://github.com/GoogleCloudPlatform/spanner-migration-tool/pull/756/files#diff-c56312e9279245ad1b77841b732d9ccdba0d4585ea7cca56433c48158b28a5f1R865-R874). 
When the caller methods are unit tested, the accessor implementors constructor should be moved up and taken as an input. In the linked example, when unit testing `StartDataflow`, `storageaccessor.StorageAccessor` will become a function parameter and `StorageAccessorImpl{}` will be passed in its place wherever `StartDataflow()` is called.
