### PR TITLE
Make fastExit false for orchestration and schema

### DIFF
--- a/conversion/data_from_database.go
+++ b/conversion/data_from_database.go
@@ -211,7 +211,7 @@ func (dd *DataFromDatabaseImpl) dataFromDatabaseForDataflowMigration(migrationPr
 		return common.TaskResult[*profiles.DataShard]{Result: p, Err: err}
 	}
 	r := common.RunParallelTasksImpl[*profiles.DataShard, *profiles.DataShard]{}
-	_, err = r.RunParallelTasks(sourceProfile.Config.ShardConfigurationDataflow.DataShards, 20, asyncProcessShards, true)
+	_, err = r.RunParallelTasks(sourceProfile.Config.ShardConfigurationDataflow.DataShards, 20, asyncProcessShards, false)
 	if err != nil {
 		return nil, fmt.Errorf("unable to start minimal downtime migrations: %v", err)
 	}

--- a/sources/common/infoschema.go
+++ b/sources/common/infoschema.go
@@ -118,7 +118,7 @@ func (is *InfoSchemaImpl) GenerateSrcSchema(conv *internal.Conv, infoSchema Info
 	}
 
 	r := RunParallelTasksImpl[SchemaAndName, SchemaAndName]{}
-	res, e := r.RunParallelTasks(tables, numWorkers, asyncProcessTable, true)
+	res, e := r.RunParallelTasks(tables, numWorkers, asyncProcessTable, false)
 	if e != nil {
 		fmt.Printf("exiting due to error: %s , while processing schema for table %s\n", e, res)
 		return 0, e


### PR DESCRIPTION
Switches `fastExit` to false so that queued tasks are not discarded.