### PR TITLE
Postgres Default Values

### DIFF
--- a/schema/schema.go
+++ b/schema/schema.go
@@ -44,6 +44,13 @@ type Table struct {
 	Id           string
 }
 
+// DefaultValue represents whether Defaultvalue is present, DefaultValue and IsSpannerSupported.
+type DefaultValue struct {
+	IsPresent          bool
+	DefaultValue       string
+	IsSpannerSupported bool
+}
+
 // Column represents a database column.
 // TODO: add support for foreign keys.
 type Column struct {
@@ -52,6 +59,7 @@ type Column struct {
 	NotNull 	bool
 	Ignored 	Ignored
 	Id      	string
+	Default DefaultValue
 }
 
 // ForeignKey represents a foreign key.

--- a/sources/postgres/infoschema.go
+++ b/sources/postgres/infoschema.go
@@ -314,12 +314,21 @@ func (isi InfoSchemaImpl) GetColumns(conv *internal.Conv, table common.SchemaAnd
 		}
 		ignored.Default = colDefault.Valid
 		colId := internal.GenerateColumnId()
+		defaultVal := schema.DefaultValue{
+			IsPresent:          colDefault.Valid,
+			DefaultValue:       "",
+			IsSpannerSupported: false,
+		}
+		if colDefault.Valid {
+			defaultVal.DefaultValue = colDefault.String
+		}
 		c := schema.Column{
 			Id:      colId,
 			Name:    colName,
 			Type:    toType(dataType, elementDataType, charMaxLen, numericPrecision, numericScale),
 			NotNull: common.ToNotNull(conv, isNullable),
 			Ignored: ignored,
+			Default: defaultVal,
 		}
 		colDefs[colId] = c
 		colIds = append(colIds, colId)


### PR DESCRIPTION
-Fixes Fetching Default Values for Postgres from Source Database

-Fetching Default Values for Postgres from source Database.
-Stores in conv object.

-Screenshot of Default Values in session json
![Screenshot from 2024-06-18 12-21-40](https://github.com/GoogleCloudPlatform/spanner-migration-tool/assets/171904753/69dcc318-2734-4198-b310-8fcbf90d7fcb)
