### PR TITLE
Making GenerateIdSuffix thread safe

### DIFF
--- a/internal/helpers.go
+++ b/internal/helpers.go
@@ -32,20 +32,20 @@ type Counter struct {
 var Cntr Counter
 
 // Thread safe Counter to generate ids in session file.
-func GenerateIdSuffix() string {
-	Cntr.counterMutex.Lock()
-	counter, _ := strconv.Atoi(Cntr.ObjectId)
+func (c *Counter) GenerateIdSuffix() string {
+	c.counterMutex.Lock()
+	counter, _ := strconv.Atoi(c.ObjectId)
 
 	counter = counter + 1
 
-	Cntr.ObjectId = strconv.Itoa(counter)
-	returnVal := Cntr.ObjectId
-	Cntr.counterMutex.Unlock()
+	c.ObjectId = strconv.Itoa(counter)
+	returnVal := c.ObjectId
+	c.counterMutex.Unlock()
 	return returnVal
 }
 
 func GenerateId(idPrefix string) string {
-	idSuffix := GenerateIdSuffix()
+	idSuffix := Cntr.GenerateIdSuffix()
 	id := idPrefix + idSuffix
 	return id
 }

--- a/internal/helpers.go
+++ b/internal/helpers.go
@@ -18,25 +18,30 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"sync"
 
 	"github.com/GoogleCloudPlatform/spanner-migration-tool/schema"
 	"github.com/GoogleCloudPlatform/spanner-migration-tool/spanner/ddl"
 )
 
 type Counter struct {
+	counterMutex sync.Mutex
 	ObjectId string
 }
 
 var Cntr Counter
 
+// Thread safe Counter to generate ids in session file.
 func GenerateIdSuffix() string {
-
+	Cntr.counterMutex.Lock()
 	counter, _ := strconv.Atoi(Cntr.ObjectId)
 
 	counter = counter + 1
 
 	Cntr.ObjectId = strconv.Itoa(counter)
-	return Cntr.ObjectId
+	returnVal := Cntr.ObjectId
+	Cntr.counterMutex.Unlock()
+	return returnVal
 }
 
 func GenerateId(idPrefix string) string {

--- a/internal/helpers_test.go
+++ b/internal/helpers_test.go
@@ -15,8 +15,8 @@
 package internal
 
 import (
-	"testing"
 	"sync"
+	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -32,12 +32,13 @@ func TestGenerateIdSuffix(t *testing.T) {
 		{10000, "40000"},
 	}
 	for _, tc := range tests {
+		counter := Counter{}
 		// Call GenerateIdSuffix n number of times parallely. 
 		for i := 0; i < tc.number; i++ {
 			// Increment the WaitGroup counter.
 			wg.Add(1)
 			go func() {
-				GenerateIdSuffix()
+				counter.GenerateIdSuffix()
 				// Decrement the counter when the goroutine completes.
 				defer wg.Done()
 			}()
@@ -45,6 +46,6 @@ func TestGenerateIdSuffix(t *testing.T) {
 		// Wait for all Go routines in the tc to complete
         wg.Wait()
 		// Assert that the counter is actually incremented to n.
-		assert.Equal(t, tc.expected, Cntr.ObjectId)
+		assert.Equal(t, tc.expected, counter.ObjectId)
 	}
 }

--- a/internal/helpers_test.go
+++ b/internal/helpers_test.go
@@ -32,6 +32,7 @@ func TestGenerateIdSuffix(t *testing.T) {
 		{10000, "40000"},
 	}
 	for _, tc := range tests {
+		// Call GenerateIdSuffix n number of times parallely. 
 		for i := 0; i < tc.number; i++ {
 			// Increment the WaitGroup counter.
 			wg.Add(1)
@@ -43,6 +44,7 @@ func TestGenerateIdSuffix(t *testing.T) {
 		}
 		// Wait for all Go routines in the tc to complete
         wg.Wait()
+		// Assert that the counter is actually incremented to n.
 		assert.Equal(t, tc.expected, Cntr.ObjectId)
 	}
 }

--- a/internal/helpers_test.go
+++ b/internal/helpers_test.go
@@ -1,0 +1,48 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"testing"
+	"sync"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGenerateIdSuffix(t *testing.T) {
+	var wg sync.WaitGroup
+	tests := []struct {
+		number     int
+		expected string
+	}{
+		{10000, "10000"},
+		{20000, "30000"},
+		{10000, "40000"},
+	}
+	for _, tc := range tests {
+		for i := 0; i < tc.number; i++ {
+			// Increment the WaitGroup counter.
+			wg.Add(1)
+			go func() {
+				GenerateIdSuffix()
+				// Decrement the counter when the goroutine completes.
+				defer wg.Done()
+			}()
+		}
+		// Wait for all Go routines in the tc to complete
+        wg.Wait()
+		assert.Equal(t, tc.expected, Cntr.ObjectId)
+	}
+}

--- a/internal/helpers_test.go
+++ b/internal/helpers_test.go
@@ -31,8 +31,8 @@ func TestGenerateIdSuffix(t *testing.T) {
 		{20000, "30000"},
 		{10000, "40000"},
 	}
+	counter := Counter{}
 	for _, tc := range tests {
-		counter := Counter{}
 		// Call GenerateIdSuffix n number of times parallely. 
 		for i := 0; i < tc.number; i++ {
 			// Increment the WaitGroup counter.


### PR DESCRIPTION
Fixes a concurrency issue in schema migration when the schema is large.

- [ ] Tests pass
- [ ] Appropriate changes to README are included in PR