### PR TITLE
Sanitize Default Value

### DIFF
--- a/sources/mysql/infoschema.go
+++ b/sources/mysql/infoschema.go
@@ -226,6 +226,7 @@ func (isi InfoSchemaImpl) GetColumns(conv *internal.Conv, table common.SchemaAnd
 		if colDefault.Valid {
 			defaultVal.Value = sanitizeDefaultValue(colDefault.String)
 		}
+		
 		c := schema.Column{
 			Id:           colId,
 			Name:         colName,

--- a/sources/mysql/infoschema.go
+++ b/sources/mysql/infoschema.go
@@ -248,7 +248,7 @@ func (isi InfoSchemaImpl) GetColumns(conv *internal.Conv, table common.SchemaAnd
 func sanitizeDefaultValue(str string) string {
 	str = strings.ReplaceAll(str, "\\", "")          // Default Value after removing all backslashes: "concat(_utf8mb4'John',_utf8mb4'swamp',_utf8mb4'span')"
 	after := strings.Replace(str, "_utf8mb4", "", 1) // Default Value after removing first "_utf8mb4": "concat('John',_utf8mb4'swamp',_utf8mb4'span')"
-	str = strings.ReplaceAll(after, "_utf8mb4", " ") // Default Value after remaining "_utf8mb4": "concat('John', 'swamp', 'span')"
+	str = strings.ReplaceAll(after, "_utf8mb4", " ") // Default Value after removing remaining "_utf8mb4": "concat('John', 'swamp', 'span')"
 	return str
 }
 

--- a/sources/mysql/infoschema.go
+++ b/sources/mysql/infoschema.go
@@ -247,7 +247,7 @@ func (isi InfoSchemaImpl) GetColumns(conv *internal.Conv, table common.SchemaAnd
 // Default Value: "concat('John', 'swamp', 'span')"
 // Default Value with extra characters: "concat(_utf8mb4\\'John\\',_utf8mb4\\'swamp\\',_utf8mb4\\'span\\')"
 func sanitizeDefaultValue(defaultValue string) string {
-	 // Default Value after removing all backslashes: "concat(_utf8mb4'John',_utf8mb4'swamp',_utf8mb4'span')"
+	// Default Value after removing all backslashes: "concat(_utf8mb4'John',_utf8mb4'swamp',_utf8mb4'span')"
 	defaultValue = strings.ReplaceAll(defaultValue, "\\", "")
 	// Default Value after removing "_utf8mb4": "concat('John', 'swamp', 'span')"
 	defaultValue = strings.ReplaceAll(defaultValue, "_utf8mb4", " ")

--- a/sources/mysql/infoschema.go
+++ b/sources/mysql/infoschema.go
@@ -241,25 +241,24 @@ func (isi InfoSchemaImpl) GetColumns(conv *internal.Conv, table common.SchemaAnd
 	return colDefs, colIds, nil
 }
 
-// sanitizeDefaultValue removes extra characters added to Default Value.
-// These extra characters are charset which are not supported by spanner.
+// sanitizeDefaultValue removes extra characters added to Default Value in information schema in MySQL.
 // Example_1:
 // Default Value: "concat('John', 'swamp', 'span')"
-// Default Value with extra characters: "concat(_utf8mb4\\'John\\',_utf8mb4\\'swamp\\',_utf8mb4\\'span\\')"
+// Default Value in MySQL infoschema with extra characters: "concat(_utf8mb4\\'John\\',_utf8mb4\\'swamp\\',_utf8mb4\\'span\\')"
 // Default Value after removing "_utf8mb4": "concat( \\'John\\',  \\'swamp\\',  \\'span\\')"
 // Default Value after removing all backslashes: "concat('John','swamp','span')"
 // Example_2:
-// Default Value: "This is a message \\\\nwith a newline\\\\rand a carriage return."
-// Default Value with extra characters: "_utf8mb4\\'This is a \\tmessage \\\\nwith a newline\\\\\\'s and \\\\ra carriage return.\\'"
+// Default Value: "This is a message \nwith a newline\rand a carriage return."
+// Default Value in MySQL infoschema with extra characters: "_utf8mb4\\'This is a \\tmessage \\\\nwith a newline\\\\\\'s and \\\\ra carriage return.\\'"
 // Default Value after removing "_utf8mb4": " \\'This is a \\tmessage \\\\nwith a newline\\\\\\'s and \\\\ra carriage return.\\'"
 // Default Value after removing all "\\\\": " \\'This is a \\tmessage \\nwith a newline\\\\'s and \\ra carriage return.\\'
 // Default Value after removing all "\\'": "'This is a 	message \\nwith a newline\\'s \\rand a carriage return.'
 func sanitizeDefaultValue(defaultValue string) string {
-// replaces all occurrences of the "_utf8mb4" pattern within the defaultValue string with a single space character (" ")
+	// replaces all occurrences of the "_utf8mb4" pattern within the defaultValue string with a single space character (" ")
 	defaultValue = strings.ReplaceAll(defaultValue, "_utf8mb4", " ")
-// replaces all occurrences of the "\\\\" pattern within the defaultValue string with "\\" to handle escape characters like \\n(new line), \\r(return carraige), \\t(tab), \\'(apostrophe)
+	// replaces all occurrences of the "\\\\" pattern within the defaultValue string with "\\" to handle escape characters like \\n(new line), \\r(return carraige), \\t(tab), \\'(apostrophe)
 	defaultValue = strings.ReplaceAll(defaultValue, "\\\\", "\\")
-// replaces all occurrences of the "\\'" pattern within the defaultValue string with a single quote character "'"
+	// replaces all occurrences of the "\\'" pattern within the defaultValue string with a single quote character "'"
 	defaultValue = strings.ReplaceAll(defaultValue, "\\'", "'")
 	return defaultValue
 }

--- a/sources/mysql/infoschema.go
+++ b/sources/mysql/infoschema.go
@@ -226,7 +226,7 @@ func (isi InfoSchemaImpl) GetColumns(conv *internal.Conv, table common.SchemaAnd
 		if colDefault.Valid {
 			defaultVal.Value = sanitizeDefaultValue(colDefault.String)
 		}
-		
+
 		c := schema.Column{
 			Id:           colId,
 			Name:         colName,

--- a/sources/mysql/infoschema.go
+++ b/sources/mysql/infoschema.go
@@ -254,11 +254,8 @@ func (isi InfoSchemaImpl) GetColumns(conv *internal.Conv, table common.SchemaAnd
 // Default Value after removing all "\\\\": " \\'This is a \\tmessage \\nwith a newline\\\\'s and \\ra carriage return.\\'
 // Default Value after removing all "\\'": "'This is a 	message \\nwith a newline\\'s \\rand a carriage return.'
 func sanitizeDefaultValue(defaultValue string) string {
-	// replaces all occurrences of the "_utf8mb4" pattern within the defaultValue string with a single space character (" ")
 	defaultValue = strings.ReplaceAll(defaultValue, "_utf8mb4", " ")
-	// replaces all occurrences of the "\\\\" pattern within the defaultValue string with "\\" to handle escape characters like \\n(new line), \\r(return carraige), \\t(tab), \\'(apostrophe)
 	defaultValue = strings.ReplaceAll(defaultValue, "\\\\", "\\")
-	// replaces all occurrences of the "\\'" pattern within the defaultValue string with a single quote character "'"
 	defaultValue = strings.ReplaceAll(defaultValue, "\\'", "'")
 	return defaultValue
 }

--- a/sources/mysql/infoschema.go
+++ b/sources/mysql/infoschema.go
@@ -241,15 +241,14 @@ func (isi InfoSchemaImpl) GetColumns(conv *internal.Conv, table common.SchemaAnd
 	return colDefs, colIds, nil
 }
 
-// SanitizeDefaultValue removes extra characters added to Default Values.
+// sanitizeDefaultValue removes extra characters added to Default Values.
 // Example:
 // Default Value: "concat('John', 'swamp', 'span')"
 // Default Value with extra characters: "concat(_utf8mb4\\'John\\',_utf8mb4\\'swamp\\',_utf8mb4\\'span\\')"
-func sanitizeDefaultValue(str string) string {
-	str = strings.ReplaceAll(str, "\\", "")          // Default Value after removing all backslashes: "concat(_utf8mb4'John',_utf8mb4'swamp',_utf8mb4'span')"
-	after := strings.Replace(str, "_utf8mb4", "", 1) // Default Value after removing first "_utf8mb4": "concat('John',_utf8mb4'swamp',_utf8mb4'span')"
-	str = strings.ReplaceAll(after, "_utf8mb4", " ") // Default Value after removing remaining "_utf8mb4": "concat('John', 'swamp', 'span')"
-	return str
+func sanitizeDefaultValue(defaultValue string) string {
+	defaultValue = strings.ReplaceAll(defaultValue, "\\", "")          // Default Value after removing all backslashes: "concat(_utf8mb4'John',_utf8mb4'swamp',_utf8mb4'span')"
+	defaultValue = strings.ReplaceAll(defaultValue, "_utf8mb4", " ") // Default Value after removing "_utf8mb4": "concat('John', 'swamp', 'span')"
+	return defaultValue
 }
 
 // GetConstraints returns a list of primary keys and by-column map of

--- a/sources/mysql/infoschema.go
+++ b/sources/mysql/infoschema.go
@@ -241,13 +241,16 @@ func (isi InfoSchemaImpl) GetColumns(conv *internal.Conv, table common.SchemaAnd
 	return colDefs, colIds, nil
 }
 
-// sanitizeDefaultValue removes extra characters added to Default Values.
+// sanitizeDefaultValue removes extra characters added to Default Value.
+// These extra characters are charset which are not supported by spanner.
 // Example:
 // Default Value: "concat('John', 'swamp', 'span')"
 // Default Value with extra characters: "concat(_utf8mb4\\'John\\',_utf8mb4\\'swamp\\',_utf8mb4\\'span\\')"
 func sanitizeDefaultValue(defaultValue string) string {
-	defaultValue = strings.ReplaceAll(defaultValue, "\\", "")          // Default Value after removing all backslashes: "concat(_utf8mb4'John',_utf8mb4'swamp',_utf8mb4'span')"
-	defaultValue = strings.ReplaceAll(defaultValue, "_utf8mb4", " ") // Default Value after removing "_utf8mb4": "concat('John', 'swamp', 'span')"
+	 // Default Value after removing all backslashes: "concat(_utf8mb4'John',_utf8mb4'swamp',_utf8mb4'span')"
+	defaultValue = strings.ReplaceAll(defaultValue, "\\", "")
+	// Default Value after removing "_utf8mb4": "concat('John', 'swamp', 'span')"
+	defaultValue = strings.ReplaceAll(defaultValue, "_utf8mb4", " ")
 	return defaultValue
 }
 

--- a/sources/mysql/infoschema_test.go
+++ b/sources/mysql/infoschema_test.go
@@ -537,12 +537,9 @@ func TestSanitizeDefaultValue(t *testing.T) {
 		{"_utf8mb4\\'This product has\tmultiple features.\\'", " 'This product has\tmultiple features.'"},
 		{"_utf8mb4\\'C:\\\\\\\\Users\\\\\\\\johndoe\\\\\\\\Documents\\\\\\\\myfile.txt\\'", " 'C:\\\\Users\\\\johndoe\\\\Documents\\\\myfile.txt'"},
 	}
-
 	for _, test := range tests {
 		result := sanitizeDefaultValue(test.input)
-		if result != test.expected {
-			t.Errorf("Actual sanitizeDefaultValue(%q) = %q; expected %q", test.input, result, test.expected)
-		}
+		assert.Equal(t, test.expected, result)
 	}
 }
 

--- a/sources/mysql/infoschema_test.go
+++ b/sources/mysql/infoschema_test.go
@@ -524,6 +524,28 @@ func TestSetRowStats(t *testing.T) {
 	assert.Equal(t, int64(0), conv.Unexpecteds())
 }
 
+func TestSanitizeDefaultValue(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"_utf8mb4\\'hello world\\'", " 'hello world'"},
+		{"week(_utf8mb4\\'2024-06-20\\',0)", "week( '2024-06-20',0)"},
+		{"_utf8mb4\\'This is a message \\\\nwith a newline\\\\rand a carriage return.\\'", " 'This is a message \\nwith a newline\\rand a carriage return.'"},
+		{"strcmp(_utf8mb4\\'abc\\',_utf8mb4\\'abcd\\')", "strcmp( 'abc', 'abcd')"},
+		{"_utf8mb4\\'John\\\\\\'s Jack\\'", " 'John\\'s Jack'"},
+		{"_utf8mb4\\'This product has\tmultiple features.\\'", " 'This product has\tmultiple features.'"},
+		{"_utf8mb4\\'C:\\\\\\\\Users\\\\\\\\johndoe\\\\\\\\Documents\\\\\\\\myfile.txt\\'", " 'C:\\\\Users\\\\johndoe\\\\Documents\\\\myfile.txt'"},
+	}
+
+	for _, test := range tests {
+		result := sanitizeDefaultValue(test.input)
+		if result != test.expected {
+			t.Errorf("Actual sanitizeDefaultValue(%q) = %q; expected %q", test.input, result, test.expected)
+		}
+	}
+}
+
 func mkMockDB(t *testing.T, ms []mockSpec) *sql.DB {
 	db, mock, err := sqlmock.New()
 	assert.Nil(t, err)


### PR DESCRIPTION
-  Some extra characters were being added to the default value. 
-  To remove those extra characters sanitizeDefaultValue function is being implemented.
-  Example:
    Default Value: "concat('John', 'swamp', 'span')"
    Default Value with extra characters: "concat(_utf8mb4\\'John\\',_utf8mb4\\'swamp\\',_utf8mb4\\'span\\')"
