### PR TITLE
Default Value Pop up Warning 

### DIFF
--- a/ui/src/app/components/direct-connection/direct-connection.component.html
+++ b/ui/src/app/components/direct-connection/direct-connection.component.html
@@ -79,7 +79,7 @@
       <button mat-raised-button id="test-connect-btn" type="submit" color="accent" [disabled]="!connectForm.valid" (click)="testConn()">
         Test Connection
       </button>
-      <button mat-raised-button id="connect-btn" type="submit" color="primary" [disabled]="!connectForm.valid || !isTestConnectionSuccessful" (click)="connectToDb()">
+      <button mat-raised-button id="connect-btn" type="submit" color="primary" [disabled]="!connectForm.valid || !isTestConnectionSuccessful" (click)="checkSpConfig()">
         Connect
       </button>
       <button mat-raised-button [routerLink]="'/'">Cancel</button>

--- a/ui/src/app/components/direct-connection/direct-connection.component.ts
+++ b/ui/src/app/components/direct-connection/direct-connection.component.ts
@@ -122,8 +122,6 @@ export class DirectConnectionComponent implements OnInit {
       dialogRef.afterClosed().subscribe((dialogResult) => {
         if (dialogResult) {
           this.connectToDb();
-        } else {
-          // user cancelled, stays on same page.
         }
       })
     } else {


### PR DESCRIPTION
- Default Values are migrated only when Spanner Configuration Details are provided.
- A pop up warning is given after clicking on "Connect" button only when Spanner Configuration Details are not provided.
- Pop up warning has two choices with a warning message, either to "Cancel" or "Continue".
- Clicking on "Cancel" , user will stay on same page to provide Spanner Configuration Details.
- Clicking on "Continue", user will be taken to workspace page without any Default Values for spanner database.
- Pop up warning image
![image](https://github.com/user-attachments/assets/7fe6966c-dea1-45f4-8fa5-59e6542d9000)
- Image of workspace when spanner configuration details are not provided (after clicking "Continue")
![image](https://github.com/user-attachments/assets/c324cf99-aa36-401d-882f-ff76b3af8e0e)
- Image of workspace when spanner configuration details are provided
![image](https://github.com/user-attachments/assets/f723e380-affe-446a-8bec-8a8fac1a489a)



