### PR TITLE
Bumping up sqlServer Image to fix issue of permission denied on `/proc/pid/task`

### DIFF
--- a/.github/workflows/integration-tests-against-emulator.yaml
+++ b/.github/workflows/integration-tests-against-emulator.yaml
@@ -81,7 +81,7 @@ jobs:
           - 8000:8000
         options: --workdir /home/dynamodblocal --health-cmd "curl --fail http://127.0.0.1:8000/shell/ || exit 1" --health-interval 10s --health-timeout 5s --health-retries 5
       sqlserver:
-        image: mcr.microsoft.com/mssql/server:2022-CU10-ubuntu-22.04
+        image: mcr.microsoft.com/mssql/server:2022-latest
         env:
           SA_PASSWORD: ${{env.MSSQL_SA_PASSWORD}}
           MSSQL_PID: Express
@@ -89,7 +89,7 @@ jobs:
         ports:
           - 1433:1433
         options:
-          --health-cmd "/opt/mssql-tools/bin/sqlcmd -U sa -P $SA_PASSWORD -Q 'select 1' -b -o /dev/null"
+          --health-cmd "/opt/mssql-tools18/bin/sqlcmd -U sa -P $SA_PASSWORD -Q 'select 1' -b -No -o /dev/null"
           --health-interval 10s --health-timeout 5s --health-retries 3
       oracle:
         image: oracleinanutshell/oracle-xe-11g


### PR DESCRIPTION
# Bumping up sqlServer Image to fix issue of permission denied on `/proc/pid/task`


**Fixes**: Failure in integration tests.
**Summary of Issue**: SqlServer initialization fails with permission denied on `/pdoc/pid/task`. As per [/mssql-docker/issues/538](https://github.com/microsoft/mssql-docker/issues/538), it's recommended to bump up the base ubuntu version of the docker image.

**Reference**: https://github.com/microsoft/mssql-docker/issues/538



- [x] Tests pass - Waiting a run of integration tests.
- [X] Appropriate changes to README are included in PR - NA