### PR TITLE
Make spanner config mandatory

### DIFF
--- a/ui/src/app/components/direct-connection/direct-connection.component.spec.ts
+++ b/ui/src/app/components/direct-connection/direct-connection.component.spec.ts
@@ -13,6 +13,7 @@ import { MatInputModule } from '@angular/material/input'
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations'
 import { SnackbarService } from 'src/app/services/snackbar/snackbar.service'
 import { MatSnackBarModule } from '@angular/material/snack-bar'
+import { MatDialogModule } from '@angular/material/dialog'
 
 const appRoutes: Routes = [{ path: 'workspace', component: WorkspaceComponent }]
 
@@ -34,6 +35,7 @@ describe('DirectConnectionComponent', () => {
         MatInputModule,
         BrowserAnimationsModule,
         MatSnackBarModule,
+        MatDialogModule
       ],
       providers: [SnackbarService],
     }).compileComponents()

--- a/ui/src/app/components/header/header.component.html
+++ b/ui/src/app/components/header/header.component.html
@@ -5,17 +5,18 @@
     <div
       class="spanner_config"
     >
+
       <mat-icon
-        *ngIf="isOfflineStatus && !showWarning()"
-        class="icon warning"
-        matTooltip="Invalid spanner configuration. Working in offline mode"
+      *ngIf="isOfflineStatus && !showError()"
+      class="icon danger"
+      matTooltip="Invalid spanner configuration. Working in offline mode"
       >
-        warning
+      error
       </mat-icon>
 
       <mat-icon
         id="check-icon"
-        *ngIf="!isOfflineStatus && !showWarning()"
+        *ngIf="!isOfflineStatus && !showError()"
         class="icon success"
         matTooltip="Valid spanner configuration."
       >
@@ -23,17 +24,17 @@
       </mat-icon>
 
       <mat-icon
-        *ngIf="showWarning()"
-        class="icon warning"
+        *ngIf="showError()"
+        class="icon danger"
         matTooltip="Spanner configuration has not been set."
       >
-        warning
+      error
       </mat-icon>
-      <div *ngIf="showWarning()">
+      <div *ngIf="showError()">
         <span #name>Spanner database is not configured, click on edit button to configure </span>
       </div>
 
-      <div *ngIf="!showWarning()">
+      <div *ngIf="!showError()">
         <span class="pid"><b>Project Id: </b>{{ spannerConfig.GCPProjectID }}</span>
         <span class="iid"><b>Spanner Instance Id: </b>{{ spannerConfig.SpannerInstanceID }}</span>
       </div>

--- a/ui/src/app/components/header/header.component.ts
+++ b/ui/src/app/components/header/header.component.ts
@@ -56,7 +56,7 @@ export class HeaderComponent implements OnInit {
     })
   }
 
-  showWarning() {
+  showError() {
     return !this.spannerConfig.GCPProjectID && !this.spannerConfig.SpannerInstanceID
   }
   openInstructionSidenav() {

--- a/ui/src/app/components/home/home.component.html
+++ b/ui/src/app/components/home/home.component.html
@@ -11,11 +11,11 @@
       color="primary"
       class="split-button-left"
       id='connect-to-database-btn'
-      [routerLink]="'/source/direct-connection'"
+      (click)="connectToDatabase()"
     >
       Connect to database
     </button>
-    <button mat-raised-button color="primary" class="split-button-right" [matMenuTriggerFor]="menu">
+    <button mat-raised-button color="primary"  class="split-button-right" [matMenuTriggerFor]="menu">
       <mat-icon aria-hidden="false" aria-label="More options">expand_more</mat-icon>
     </button>
     <mat-menu #menu="matMenu" xPosition="before">

--- a/ui/src/app/components/home/home.component.spec.ts
+++ b/ui/src/app/components/home/home.component.spec.ts
@@ -1,20 +1,29 @@
 import { HttpClientModule } from '@angular/common/http'
 import { ComponentFixture, TestBed } from '@angular/core/testing'
-import { MatDialogModule, MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog'
+import { MatDialogModule, MatDialogRef, MAT_DIALOG_DATA, MatDialog } from '@angular/material/dialog'
 import { MatMenuModule } from '@angular/material/menu'
-import { RouterModule, Routes } from '@angular/router'
+import { Router, RouterModule, Routes } from '@angular/router'
 import { WorkspaceComponent } from '../workspace/workspace.component'
 import { HomeComponent } from './home.component'
+import { MatSnackBarModule } from '@angular/material/snack-bar'
+import { InfodialogComponent } from '../infodialog/infodialog.component'
+import { DataService } from 'src/app/services/data/data.service'
+import { BehaviorSubject } from 'rxjs'
 const appRoutes: Routes = [{ path: 'workspace', component: WorkspaceComponent }]
 
 describe('HomeComponent', () => {
   let component: HomeComponent
   let fixture: ComponentFixture<HomeComponent>
+  let dataService: DataService;
+  let dialog: MatDialog;
+  let router: Router;
+  const isOfflineSubject = new BehaviorSubject<boolean>(true);
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
+
       declarations: [HomeComponent],
-      imports: [MatMenuModule, MatDialogModule, RouterModule.forRoot(appRoutes), HttpClientModule],
+      imports: [MatMenuModule, MatDialogModule, RouterModule.forRoot(appRoutes), HttpClientModule,MatSnackBarModule],
       providers: [
         {
           provide: MatDialogRef,
@@ -22,6 +31,7 @@ describe('HomeComponent', () => {
             close: () => {},
           },
         },
+        { provide: DataService, useValue: { isOffline: isOfflineSubject.asObservable() } },
         {
           provide: MAT_DIALOG_DATA,
           useValue: {
@@ -33,6 +43,9 @@ describe('HomeComponent', () => {
 
   beforeEach(() => {
     fixture = TestBed.createComponent(HomeComponent)
+    dataService = TestBed.inject(DataService);
+    dialog = TestBed.inject(MatDialog);
+    router = TestBed.inject(Router);
     component = fixture.componentInstance
     fixture.detectChanges()
   })
@@ -40,4 +53,37 @@ describe('HomeComponent', () => {
   it('should create', () => {
     expect(component).toBeTruthy()
   })
+
+  it('should set isOfflineStatus when isOffline emits a value', () => {
+    isOfflineSubject.next(true); // Emit true
+    fixture.detectChanges();
+    expect(component.isOfflineStatus).toBeTrue();
+  });
+
+  it('should open dialog if isOfflineStatus is true', () => {
+
+    isOfflineSubject.next(true);
+    fixture.detectChanges();
+
+    spyOn(dialog, 'open').and.callThrough();
+
+    component.connectToDatabase();
+
+    expect(dialog.open).toHaveBeenCalledWith(InfodialogComponent, {
+      data: { message: 'Please configure spanner project id and instance id to proceed', type: 'error', title: 'Configure Spanner' },
+      maxWidth: '500px',
+    });
+  });
+
+  it('should navigate to direct connection if isOfflineStatus is false', () => {
+    isOfflineSubject.next(false);
+    fixture.detectChanges();
+
+    spyOn(router, 'navigate');
+
+    component.connectToDatabase();
+
+    expect(router.navigate).toHaveBeenCalledWith(['/source/direct-connection']);
+  });
+
 })

--- a/ui/src/app/components/home/home.component.ts
+++ b/ui/src/app/components/home/home.component.ts
@@ -4,6 +4,7 @@ import { Router } from '@angular/router';
 import { MigrationDetails } from 'src/app/app.constants';
 import { BackendHealthService } from 'src/app/services/backend-health/backend-health.service';
 import { InfodialogComponent } from '../infodialog/infodialog.component';
+import { DataService } from 'src/app/services/data/data.service';
 
 @Component({
   selector: 'app-home',
@@ -11,11 +12,22 @@ import { InfodialogComponent } from '../infodialog/infodialog.component';
   styleUrls: ['./home.component.scss'],
 })
 export class HomeComponent implements OnInit {
+  isOfflineStatus: boolean = false
+
   constructor(private dialog: MatDialog,
     private router: Router,
-    private healthCheckService: BackendHealthService) { }
+    private data: DataService,
+    private healthCheckService: BackendHealthService) {
+
+     }
 
   ngOnInit(): void {
+    this.data.isOffline.subscribe({
+      next: (res: boolean) => {
+        this.isOfflineStatus = res
+      },
+    })
+
     this.healthCheckService.startHealthCheck();
     if (localStorage.getItem(MigrationDetails.IsMigrationInProgress) != null && localStorage.getItem(MigrationDetails.IsMigrationInProgress) as string === 'true') {
       this.dialog.open(InfodialogComponent, {
@@ -23,6 +35,18 @@ export class HomeComponent implements OnInit {
         maxWidth: '500px',
       })
       this.router.navigate(['/prepare-migration'])
+    }
+  }
+
+  connectToDatabase(){
+    if(this.isOfflineStatus){
+      this.dialog.open(InfodialogComponent, {
+        data: { message: "Please configure spanner project id and instance id to proceed", type: 'error', title: 'Configure Spanner' },
+        maxWidth: '500px',
+      })
+    }
+    else{
+      this.router.navigate(['/source/direct-connection'])
     }
   }
 }


### PR DESCRIPTION
Fixes #<issue_number_goes_here>

> It's a good idea to open an issue first for discussion.

- [x] Tests pass
- [ ] Appropriate changes to README are included in PR


Currently, setting up of the Project ID and Spanner Instance ID is optional on the initial pages. With the new Verification API workflow, this is required to be mandatory. If the Spanner config are not set or invalid, the user shall receieve similar pop-up shown below before they can move forward with the schema migration.

<img width="1438" alt="394111866-129acc39-6981-4e5a-b282-d21e8688e1c4" src="https://github.com/user-attachments/assets/da873ae7-369e-453e-8749-68634f7a4ab1">
