### PR TITLE
Replace ReadOnlyTransaction() with Single()

### DIFF
--- a/accessors/clients/spanner/client/interface.go
+++ b/accessors/clients/spanner/client/interface.go
@@ -46,7 +46,7 @@ func (c *SpannerClientImpl) Refresh(ctx context.Context, dbURI string) error {
 }
 
 func (c *SpannerClientImpl) Single() ReadOnlyTransaction {
-	rotxn := c.spannerClient.ReadOnlyTransaction()
+	rotxn := c.spannerClient.Single()
 	return &ReadOnlyTransactionImpl{rotxn: rotxn}
 }
 


### PR DESCRIPTION
During mocking the `Single()` method of the client library, we used the `ReadOnlyTransaction()` method to return an instance of a ReadOnlyTransaction. This is different from the `ReadOnlyTransaction` object that gets returned from the `Single()` method, which is more suited to single use transactions that we use in the expressions API for verification.

This caused the nature of the ReadOnlyTransactions being used to change from being `SingleUse` to non-SingleUse, which would then cause session leaks since they were not automatically getting cleaned up.

Using `Single()` fixes the session leak, and has been validated by running 20K CHECK constraint validations. 