### PR TITLE
bugfix - Check Constraint PG Dialect

### DIFF
--- a/internal/reports/report_helpers.go
+++ b/internal/reports/report_helpers.go
@@ -114,6 +114,12 @@ func buildTableReportBody(conv *internal.Conv, tableId string, issues map[string
 		// added if condition to add table level warnings
 		if p.severity == warning && len(conv.InvalidCheckExp[tableId]) != 0 {
 			for _, invalidExp := range conv.InvalidCheckExp[tableId] {
+				var backtickMsg string = ""
+				var dialectMsg string = "with the constraint logic"
+				if conv.SpDialect == constants.DIALECT_POSTGRESQL && strings.ContainsAny(invalidExp.Expression, "`") {
+					backtickMsg = "caused by backticks"
+					dialectMsg = "with the PostgreSQL dialect"
+				}
 				switch invalidExp.IssueType {
 				case internal.TypeMismatch:
 					toAppend := Issue{
@@ -124,7 +130,7 @@ func buildTableReportBody(conv *internal.Conv, tableId string, issues map[string
 				case internal.InvalidCondition:
 					toAppend := Issue{
 						Category:    IssueDB[invalidExp.IssueType].Category,
-						Description: fmt.Sprintf("Table '%s': The check constraint %s contains an invalid condition that is incompatible with constraint logic. As a result, the check constraint has not been applied and has been dropped", conv.SpSchema[tableId].Name, invalidExp.Expression),
+						Description: fmt.Sprintf("Table '%s': The check constraint %s contains an invalid condition %s that is incompatible %s. As a result, the check constraint has not been applied and has been dropped", conv.SpSchema[tableId].Name, invalidExp.Expression, backtickMsg, dialectMsg),
 					}
 					l = append(l, toAppend)
 				case internal.ColumnNotFound:
@@ -154,6 +160,13 @@ func buildTableReportBody(conv *internal.Conv, tableId string, issues map[string
 		if p.severity == Errors && len(conv.InvalidCheckExp[tableId]) != 0 {
 
 			for _, invalidExp := range conv.InvalidCheckExp[tableId] {
+				var backtickMsg string = ""
+				var dialectMsg string = "with the constraint logic"
+				if conv.SpDialect == constants.DIALECT_POSTGRESQL && strings.ContainsAny(invalidExp.Expression, "`") {
+					backtickMsg = "caused by backticks"
+					dialectMsg = "with the PostgreSQL dialect"
+				}
+
 				switch invalidExp.IssueType {
 				case internal.TypeMismatchError:
 					toAppend := Issue{
@@ -164,7 +177,7 @@ func buildTableReportBody(conv *internal.Conv, tableId string, issues map[string
 				case internal.InvalidConditionError:
 					toAppend := Issue{
 						Category:    IssueDB[invalidExp.IssueType].Category,
-						Description: fmt.Sprintf("Table '%s': The check constraint %s contains an invalid condition that is incompatible with the constraint logic. Kindly address the errors related to the check constraint", conv.SpSchema[tableId].Name, invalidExp.Expression),
+						Description: fmt.Sprintf("Table '%s': The check constraint %s contains an invalid condition %s that is incompatible %s. Kindly address the errors related to the check constraint", conv.SpSchema[tableId].Name, invalidExp.Expression, backtickMsg, dialectMsg),
 					}
 					l = append(l, toAppend)
 				case internal.ColumnNotFoundError:

--- a/sources/common/toddl.go
+++ b/sources/common/toddl.go
@@ -167,7 +167,7 @@ func GetIssue(result internal.VerifyExpressionsOutput) (map[string][]internal.In
 			switch {
 			case strings.Contains(ev.Err.Error(), "No matching signature for operator"):
 				issue = internal.TypeMismatch
-			case strings.Contains(ev.Err.Error(), "Syntax error"):
+			case strings.Contains(ev.Err.Error(), "Syntax error") || strings.Contains(ev.Err.Error(), "syntax error at or near"):
 				issue = internal.InvalidCondition
 			case strings.Contains(ev.Err.Error(), "Unrecognized name"):
 				issue = internal.ColumnNotFound
@@ -209,7 +209,7 @@ func GetErroredIssue(result internal.VerifyExpressionsOutput) map[string][]inter
 			switch {
 			case strings.Contains(ev.Err.Error(), "No matching signature for operator"):
 				issue = internal.TypeMismatchError
-			case strings.Contains(ev.Err.Error(), "Syntax error"):
+			case strings.Contains(ev.Err.Error(), "Syntax error") || strings.Contains(ev.Err.Error(), "syntax error at or near"):
 				issue = internal.InvalidConditionError
 			case strings.Contains(ev.Err.Error(), "Unrecognized name"):
 				issue = internal.ColumnNotFoundError


### PR DESCRIPTION
1. Update and handle the error/warning message for unsupported backticks on check constraints with PG dialect.
2. Bug fix to display the CHECK CONSTRAINTS on the SQL tab.


![Screenshot 2025-02-03 at 4 30 24 PM](https://github.com/user-attachments/assets/7b49bfd9-1f7c-4787-b34c-30982ab4e930)
![Screenshot 2025-02-03 at 4 37 19 PM](https://github.com/user-attachments/assets/b0af6709-9019-491e-9a4c-91db0a94ec25)
