### PR TITLE
fix: Query modification and Refresh Client Issue

### DIFF
--- a/sources/common/dbdump.go
+++ b/sources/common/dbdump.go
@@ -42,7 +42,10 @@ func ProcessDbDump(conv *internal.Conv, r *internal.Reader, dbDump DbDump, ddlVe
 			ExpressionVerificationAccessor: exprVerifier,
 			DdlV:                           ddlVerifier,
 		}
-		schemaToSpanner.SchemaToSpannerDDL(conv, dbDump.GetToDdl(), internal.AdditionalSchemaAttributes{})
+		err := schemaToSpanner.SchemaToSpannerDDL(conv, dbDump.GetToDdl(), internal.AdditionalSchemaAttributes{})
+		if err != nil {
+			return err
+		}
 		conv.AddPrimaryKeys()
 	}
 	return nil

--- a/sources/common/infoschema.go
+++ b/sources/common/infoschema.go
@@ -89,7 +89,10 @@ func (ps *ProcessSchemaImpl) ProcessSchema(conv *internal.Conv, infoSchema InfoS
 	}
 	uo.initPrimaryKeyOrder(conv)
 	uo.initIndexOrder(conv)
-	s.SchemaToSpannerDDL(conv, infoSchema.GetToDdl(), attributes)
+	err = s.SchemaToSpannerDDL(conv, infoSchema.GetToDdl(), attributes)
+	if err != nil {
+		return err
+	}
 	if tableCount != len(conv.SpSchema) {
 		fmt.Printf("Failed to load all the source tables, source table count: %v, processed tables:%v. Please retry connecting to the source database to load tables.\n", tableCount, len(conv.SpSchema))
 		return fmt.Errorf("failed to load all the source tables, source table count: %v, processed tables:%v. Please retry connecting to the source database to load tables.", tableCount, len(conv.SpSchema))

--- a/sources/mysql/infoschema.go
+++ b/sources/mysql/infoschema.go
@@ -292,7 +292,7 @@ func (isi InfoSchemaImpl) getConstraintsDQL() (string, error) {
             AND t.TABLE_NAME = k.TABLE_NAME
             LEFT JOIN INFORMATION_SCHEMA.CHECK_CONSTRAINTS AS c
             ON t.CONSTRAINT_NAME = c.CONSTRAINT_NAME
-			AND t.CONSTRAINT_SCHEMA = k.CONSTRAINT_SCHEMA
+			AND t.TABLE_SCHEMA = c.CONSTRAINT_SCHEMA
             WHERE t.TABLE_SCHEMA = ? 
             AND t.TABLE_NAME = ?;`, nil
 	}

--- a/sources/mysql/infoschema.go
+++ b/sources/mysql/infoschema.go
@@ -292,6 +292,7 @@ func (isi InfoSchemaImpl) getConstraintsDQL() (string, error) {
             AND t.TABLE_NAME = k.TABLE_NAME
             LEFT JOIN INFORMATION_SCHEMA.CHECK_CONSTRAINTS AS c
             ON t.CONSTRAINT_NAME = c.CONSTRAINT_NAME
+			AND t.CONSTRAINT_SCHEMA = k.CONSTRAINT_SCHEMA
             WHERE t.TABLE_SCHEMA = ? 
             AND t.TABLE_NAME = ?;`, nil
 	}

--- a/sources/mysql/infoschema.go
+++ b/sources/mysql/infoschema.go
@@ -292,7 +292,7 @@ func (isi InfoSchemaImpl) getConstraintsDQL() (string, error) {
             AND t.TABLE_NAME = k.TABLE_NAME
             LEFT JOIN INFORMATION_SCHEMA.CHECK_CONSTRAINTS AS c
             ON t.CONSTRAINT_NAME = c.CONSTRAINT_NAME
-			AND t.TABLE_SCHEMA = c.CONSTRAINT_SCHEMA
+	    AND t.TABLE_SCHEMA = c.CONSTRAINT_SCHEMA
             WHERE t.TABLE_SCHEMA = ? 
             AND t.TABLE_NAME = ?;`, nil
 	}

--- a/sources/mysql/infoschema_test.go
+++ b/sources/mysql/infoschema_test.go
@@ -672,7 +672,7 @@ func TestGetConstraints_CheckConstraintsTableExists(t *testing.T) {
             AND t.TABLE_NAME = k.TABLE_NAME
             LEFT JOIN INFORMATION_SCHEMA.CHECK_CONSTRAINTS AS c
             ON t.CONSTRAINT_NAME = c.CONSTRAINT_NAME
-			AND AND t.TABLE_SCHEMA = c.CONSTRAINT_SCHEMA
+			AND t.TABLE_SCHEMA = c.CONSTRAINT_SCHEMA
             WHERE t.TABLE_SCHEMA = ? 
             AND t.TABLE_NAME = ?;`),
 			args: []driver.Value{"test_schema", "test_table"},

--- a/sources/mysql/infoschema_test.go
+++ b/sources/mysql/infoschema_test.go
@@ -672,7 +672,7 @@ func TestGetConstraints_CheckConstraintsTableExists(t *testing.T) {
             AND t.TABLE_NAME = k.TABLE_NAME
             LEFT JOIN INFORMATION_SCHEMA.CHECK_CONSTRAINTS AS c
             ON t.CONSTRAINT_NAME = c.CONSTRAINT_NAME
-			AND t.TABLE_SCHEMA = c.CONSTRAINT_SCHEMA
+	    AND t.TABLE_SCHEMA = c.CONSTRAINT_SCHEMA
             WHERE t.TABLE_SCHEMA = ? 
             AND t.TABLE_NAME = ?;`),
 			args: []driver.Value{"test_schema", "test_table"},

--- a/sources/mysql/infoschema_test.go
+++ b/sources/mysql/infoschema_test.go
@@ -672,6 +672,7 @@ func TestGetConstraints_CheckConstraintsTableExists(t *testing.T) {
             AND t.TABLE_NAME = k.TABLE_NAME
             LEFT JOIN INFORMATION_SCHEMA.CHECK_CONSTRAINTS AS c
             ON t.CONSTRAINT_NAME = c.CONSTRAINT_NAME
+			AND t.CONSTRAINT_SCHEMA = k.CONSTRAINT_SCHEMA
             WHERE t.TABLE_SCHEMA = ? 
             AND t.TABLE_NAME = ?;`),
 			args: []driver.Value{"test_schema", "test_table"},

--- a/sources/mysql/infoschema_test.go
+++ b/sources/mysql/infoschema_test.go
@@ -672,7 +672,7 @@ func TestGetConstraints_CheckConstraintsTableExists(t *testing.T) {
             AND t.TABLE_NAME = k.TABLE_NAME
             LEFT JOIN INFORMATION_SCHEMA.CHECK_CONSTRAINTS AS c
             ON t.CONSTRAINT_NAME = c.CONSTRAINT_NAME
-			AND t.CONSTRAINT_SCHEMA = k.CONSTRAINT_SCHEMA
+			AND AND t.TABLE_SCHEMA = c.CONSTRAINT_SCHEMA
             WHERE t.TABLE_SCHEMA = ? 
             AND t.TABLE_NAME = ?;`),
 			args: []driver.Value{"test_schema", "test_table"},

--- a/webv2/api/schema.go
+++ b/webv2/api/schema.go
@@ -644,6 +644,7 @@ func (expressionVerificationHandler *ExpressionsVerificationHandler) VerifyCheck
 		}
 
 		sessionState.Conv.SchemaIssues = common.RemoveError(sessionState.Conv.SchemaIssues)
+		expressionVerificationHandler.ExpressionVerificationAccessor.RefreshSpannerClient(ctx, sessionState.Conv.SpProjectId, sessionState.Conv.SpInstanceId)
 		result := expressionVerificationHandler.ExpressionVerificationAccessor.VerifyExpressions(ctx, verifyExpressionsInput)
 		if result.ExpressionVerificationOutputList == nil {
 			http.Error(w, fmt.Sprintf("Unhandled error: : %s", result.Err.Error()), http.StatusInternalServerError)

--- a/webv2/api/schema_test.go
+++ b/webv2/api/schema_test.go
@@ -2870,6 +2870,7 @@ func TestVerifyCheckConstraintExpressions(t *testing.T) {
 				ExpressionVerificationOutputList: tc.expectedResults,
 			})
 
+			mockAccessor.On("RefreshSpannerClient", ctx, mock.Anything, mock.Anything).Return(nil)
 			rr := httptest.NewRecorder()
 			handler.VerifyCheckConstraintExpression(rr, req)
 


### PR DESCRIPTION
1. Updated the query to get constraint details.  Issue fixed when the same constraint names are used across different databases.
2. Additional error handling when SchemaToSpannerDDL fails.
3. Added RefreshSpannerClient call for VerifyCheckConstraintExpression API call