### PR TITLE
Fix: Error Handling for CLI flow using Session file 

### DIFF
--- a/cmd/schema.go
+++ b/cmd/schema.go
@@ -142,6 +142,7 @@ func (cmd *SchemaCmd) Execute(ctx context.Context, f *flag.FlagSet, _ ...interfa
 		err := schemaToSpanner.VerifyExpressions(conv)
 
 		if err != nil {
+			logger.Log.Error(fmt.Sprintf("Error while verifying the expressions %v", err))
 			return subcommands.ExitFailure
 		}
 	} else {


### PR DESCRIPTION
1. What was the observation?
     a. The CLI flow to run schema command with the session file exits without any error message on the Terminal in case of an error from the Validation API

2. How did the issue occur?
   a. During the execution of the schema command with the session flag, the verification API call attempts to create a
       temporary database. If Spanner is exhausted or throws any other error and cannot fulfil this request, the command silently exits without logging an error.

3. What is the impact?
     a. Users cannot identify or understand the failure due to the lack of error messages or logs when Spanner is exhausted. This can lead to confusion and difficulty in diagnosing the issue.

4. Steps to resolve the above problem:

    a. Added logger message to ensure users receive appropriate logs when the command exits due to Spanner
    exhaustion or any other errors.

- [x] Tests pass
- [ ] Appropriate changes to README are included in PR