### PR TITLE
Refactoring tests for CLI cmds

### DIFF
--- a/cmd/data_test.go
+++ b/cmd/data_test.go
@@ -17,20 +17,19 @@ package cmd
 import (
         "flag"
         "testing"
-
         "github.com/GoogleCloudPlatform/spanner-migration-tool/common/constants"
         "github.com/stretchr/testify/assert"
 )
 
 func TestDataSetFlags(t *testing.T) {
-        testCases:=struct {
+        testCases:=[]struct {
                 testName       string
-                flagArgs      string
+                flagArgs      []string
                 expectedValues DataCmd
         }{
                 {
                         testName: "Default Values",
-                        flagArgs:string{},
+                        flagArgs:[]string{},
                         expectedValues: DataCmd{
                                 source:           "",
                                 sourceProfile:    "",

--- a/cmd/data_test.go
+++ b/cmd/data_test.go
@@ -15,31 +15,45 @@
 package cmd
 
 import (
-	"flag"
-	"testing"
+        "flag"
+        "testing"
 
-	"github.com/GoogleCloudPlatform/spanner-migration-tool/common/constants"
-	"github.com/stretchr/testify/assert"
+        "github.com/GoogleCloudPlatform/spanner-migration-tool/common/constants"
+        "github.com/stretchr/testify/assert"
 )
 
 func TestDataSetFlags(t *testing.T) {
-	testName := "Default Values"
-	expectedValues := DataCmd{
-		source:           "",
-		sourceProfile:    "",
-		target:           "Spanner",
-		targetProfile:    "",
-		filePrefix:       "",
-		WriteLimit:       DefaultWritersLimit,
-		dryRun:           false,
-		logLevel:         "DEBUG",
-		SkipForeignKeys:  false,
-		validate:         false,
-		dataflowTemplate: constants.DEFAULT_TEMPLATE_PATH,
-	}
+        testCases:=struct {
+                testName       string
+                flagArgs      string
+                expectedValues DataCmd
+        }{
+                {
+                        testName: "Default Values",
+                        flagArgs:string{},
+                        expectedValues: DataCmd{
+                                source:           "",
+                                sourceProfile:    "",
+                                target:           "Spanner",
+                                targetProfile:    "",
+                                filePrefix:       "",
+                                WriteLimit:       DefaultWritersLimit,
+                                dryRun:           false,
+                                logLevel:         "DEBUG",
+                                SkipForeignKeys:  false,
+                                validate:         false,
+                                dataflowTemplate: constants.DEFAULT_TEMPLATE_PATH,
+                        },
+                },
+        }
 
-	dataCmd := DataCmd{}
-	fs := flag.NewFlagSet("testSetFlags", flag.ContinueOnError)
-	dataCmd.SetFlags(fs)
-	assert.Equal(t, expectedValues, dataCmd, testName)
+        for _, tc:= range testCases {
+                t.Run(tc.testName, func(t *testing.T) {
+                        fs:= flag.NewFlagSet("testSetFlags", flag.ContinueOnError)
+                        fs.Parse(tc.flagArgs)
+                        dataCmd:= DataCmd{}
+                        dataCmd.SetFlags(fs)
+                        assert.Equal(t, tc.expectedValues, dataCmd, tc.testName)
+                })
+        }
 }

--- a/cmd/schema_and_data_test.go
+++ b/cmd/schema_and_data_test.go
@@ -15,7 +15,7 @@ func TestSchemaAndDataSetFlags(t *testing.T) {
         }{
                 {
                         testName: "Default Values",
-                        flagArgs: string{},
+                        flagArgs: []string{},
                         expectedValues: SchemaAndDataCmd{
                                 source:           "",
                                 sourceProfile:    "",
@@ -32,17 +32,17 @@ func TestSchemaAndDataSetFlags(t *testing.T) {
                 },
                 {
                         testName: "Non-Default Values",
-                        flagArgs:string{
-                                "-source=MySQL",
-                                "-source-profile=file=test.sql",
-                                "-target=Spanner",
-                                "-target-profile=instance=test-instance",
-                                "-prefix=test-prefix",
-                                "-write-limit=1000",
-                                "-dry-run",
-                                "-log-level=INFO",
-                                "-skip-foreign-keys",
-                                "-validate",
+                        flagArgs:[]string{
+                            "-source=MySQL",
+                            "-source-profile=file=test.sql",
+                            "-target=Spanner",
+                            "-target-profile=instance=test-instance",
+                            "-prefix=test-prefix",
+                            "-write-limit=1000",
+                            "-dry-run",
+                            "-log-level=INFO",
+                            "-skip-foreign-keys",
+                            "-validate",
                         },
                         expectedValues: SchemaAndDataCmd{
                                 source:           "MySQL",

--- a/cmd/schema_and_data_test.go
+++ b/cmd/schema_and_data_test.go
@@ -44,6 +44,7 @@ func TestSchemaAndDataCmd_SetFlags_DefaultValues(t *testing.T) {
 }
 
 func TestSchemaAndDataCmd_SetFlags_NonDefaultValues(t *testing.T) {
+        fs:= flag.NewFlagSet("testSetFlags", flag.ContinueOnError)
         fs.String("source", "MySQL", "")
         fs.String("source-profile", "file=test.sql", "")
         fs.String("target", "Spanner", "")
@@ -70,12 +71,12 @@ func TestSchemaAndDataCmd_SetFlags_NonDefaultValues(t *testing.T) {
         }
 
         schemaAndDataCmd:= SchemaAndDataCmd{}
-        fs:= flag.NewFlagSet("testSetFlags", flag.ContinueOnError)
         schemaAndDataCmd.SetFlags(fs)
         assert.Equal(t, expectedValues, schemaAndDataCmd, "Non-Default Values")
 }
 
 func TestSchemaAndDataCmd_SetFlags_InvalidLogLevel(t *testing.T) {
+        fs:= flag.NewFlagSet("testSetFlags", flag.ContinueOnError)
         fs.String("log-level", "INVALID", "")
 
         expectedValues:= SchemaAndDataCmd{
@@ -93,12 +94,12 @@ func TestSchemaAndDataCmd_SetFlags_InvalidLogLevel(t *testing.T) {
         }
 
         schemaAndDataCmd:= SchemaAndDataCmd{}
-        fs:= flag.NewFlagSet("testSetFlags", flag.ContinueOnError)
         schemaAndDataCmd.SetFlags(fs)
         assert.Equal(t, expectedValues, schemaAndDataCmd, "Invalid Log Level")
 }
 
 func TestSchemaAndDataCmd_SetFlags_EmptySourceProfile(t *testing.T) {
+        fs:= flag.NewFlagSet("testSetFlags", flag.ContinueOnError)
         fs.String("source", "MySQL", "")
         fs.String("source-profile", "", "")
 
@@ -117,7 +118,6 @@ func TestSchemaAndDataCmd_SetFlags_EmptySourceProfile(t *testing.T) {
         }
 
         schemaAndDataCmd:= SchemaAndDataCmd{}
-        fs:= flag.NewFlagSet("testSetFlags", flag.ContinueOnError)
         schemaAndDataCmd.SetFlags(fs)
         assert.Equal(t, expectedValues, schemaAndDataCmd, "Empty Source Profile")
 }

--- a/cmd/schema_and_data_test.go
+++ b/cmd/schema_and_data_test.go
@@ -1,17 +1,3 @@
-// Copyright 2024 Google LLC
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
 package cmd
 
 import (
@@ -22,102 +8,105 @@ import (
         "github.com/stretchr/testify/assert"
 )
 
-func TestSchemaAndDataCmd_SetFlags_DefaultValues(t *testing.T) {
-        expectedValues:= SchemaAndDataCmd{
-                source:           "",
-                sourceProfile:    "",
-                target:           "Spanner",
-                targetProfile:    "",
-                filePrefix:       "",
-                WriteLimit:       DefaultWritersLimit,
-                dryRun:           false,
-                logLevel:         "DEBUG",
-                SkipForeignKeys:  false,
-                validate:         false,
-                dataflowTemplate: constants.DEFAULT_TEMPLATE_PATH,
+func TestSchemaAndDataSetFlags(t *testing.T) {
+        testCases:=struct {
+                testName       string
+                flagArgs      string
+                expectedValues SchemaAndDataCmd
+        }{
+                {
+                        testName: "Default Values",
+                        expectedValues: SchemaAndDataCmd{
+                                source:           "",
+                                sourceProfile:    "",
+                                target:           "Spanner",
+                                targetProfile:    "",
+                                filePrefix:       "",
+                                WriteLimit:       DefaultWritersLimit,
+                                dryRun:           false,
+                                logLevel:         "DEBUG",
+                                SkipForeignKeys:  false,
+                                validate:         false,
+                                dataflowTemplate: constants.DEFAULT_TEMPLATE_PATH,
+                        },
+                },
+                {
+                        testName: "Non-Default Values",
+                        flagArgs:string{
+                                "-source=MySQL",
+                                "-source-profile=file=test.sql",
+                                "-target=Spanner",
+                                "-target-profile=instance=test-instance",
+                                "-prefix=test-prefix",
+                                "-write-limit=1000",
+                                "-dry-run",
+                                "-log-level=INFO",
+                                "-skip-foreign-keys",
+                                "-validate",
+                        },
+                        expectedValues: SchemaAndDataCmd{
+                                source:           "MySQL",
+                                sourceProfile:    "file=test.sql",
+                                target:           "Spanner",
+                                targetProfile:    "instance=test-instance",
+                                filePrefix:       "test-prefix",
+                                WriteLimit:       1000,
+                                dryRun:           true,
+                                logLevel:         "INFO",
+                                SkipForeignKeys:  true,
+                                validate:         true,
+                                dataflowTemplate: constants.DEFAULT_TEMPLATE_PATH,
+                        },
+                },
+                {
+                        testName: "Invalid Log Level",
+                        flagArgs:string{
+                                "-log-level=INVALID",
+                        },
+                        expectedValues: SchemaAndDataCmd{
+                                source:           "",
+                                sourceProfile:    "",
+                                target:           "Spanner",
+                                targetProfile:    "",
+                                filePrefix:       "",
+                                WriteLimit:       DefaultWritersLimit,
+                                dryRun:           false,
+                                logLevel:         "DEBUG", // Should remain at the default value
+                                SkipForeignKeys:  false,
+                                validate:         false,
+                                dataflowTemplate: constants.DEFAULT_TEMPLATE_PATH,
+                        },
+                },
+                {
+                        testName: "Empty Source Profile",
+                        flagArgs:string{
+                                "-source=MySQL",
+                                "-source-profile=",
+                        },
+                        expectedValues: SchemaAndDataCmd{
+                                source:           "MySQL",
+                                sourceProfile:    "", // Should be an empty string
+                                target:           "Spanner",
+                                targetProfile:    "",
+                                filePrefix:       "",
+                                WriteLimit:       DefaultWritersLimit,
+                                dryRun:           false,
+                                logLevel:         "DEBUG",
+                                SkipForeignKeys:  false,
+                                validate:         false,
+                                dataflowTemplate: constants.DEFAULT_TEMPLATE_PATH,
+                        },
+                },
         }
 
-        schemaAndDataCmd:= SchemaAndDataCmd{}
-        fs:= flag.NewFlagSet("testSetFlags", flag.ContinueOnError)
-        schemaAndDataCmd.SetFlags(fs)
-        assert.Equal(t, expectedValues, schemaAndDataCmd, "Default Values")
-}
+        for _, tc:= range testCases { // Now it can range over testCases
+                t.Run(tc.testName, func(t *testing.T) {
+                        fs:= flag.NewFlagSet("testSetFlags", flag.ContinueOnError)
+                        fs.Parse(tc.flagArgs)
 
-func TestSchemaAndDataCmd_SetFlags_NonDefaultValues(t *testing.T) {
-        fs:= flag.NewFlagSet("testSetFlagsnondefault", flag.ContinueOnError)
-        fs.String("source", "MySQL", "")
-        fs.String("source-profile", "file=test.sql", "")
-        fs.String("target", "Spanner", "")
-        fs.String("target-profile", "instance=test-instance", "")
-        fs.String("prefix", "test-prefix", "")
-        fs.Int64("write-limit", 1000, "")
-        fs.Bool("dry-run", true, "")
-        fs.String("log-level", "INFO", "")
-        fs.Bool("skip-foreign-keys", true, "")
-        fs.Bool("validate", true, "")
-
-        expectedValues:= SchemaAndDataCmd{
-                source:           "MySQL",
-                sourceProfile:    "file=test.sql",
-                target:           "Spanner",
-                targetProfile:    "instance=test-instance",
-                filePrefix:       "test-prefix",
-                WriteLimit:       1000,
-                dryRun:           true,
-                logLevel:         "INFO",
-                SkipForeignKeys:  true,
-                validate:         true,
-                dataflowTemplate: constants.DEFAULT_TEMPLATE_PATH,
+                        schemaAndDataCmd:= SchemaAndDataCmd{}
+                        schemaAndDataCmd.SetFlags(fs)
+                        assert.Equal(t, tc.expectedValues, schemaAndDataCmd, tc.testName)
+                })
         }
-
-        schemaAndDataCmd:= SchemaAndDataCmd{}
-        schemaAndDataCmd.SetFlags(fs)
-        assert.Equal(t, expectedValues, schemaAndDataCmd, "Non-Default Values")
-}
-
-func TestSchemaAndDataCmd_SetFlags_InvalidLogLevel(t *testing.T) {
-        fs:= flag.NewFlagSet("testSetFlagsinvalidlog", flag.ContinueOnError)
-        fs.String("log-level", "INVALID", "")
-
-        expectedValues:= SchemaAndDataCmd{
-                source:           "",
-                sourceProfile:    "",
-                target:           "Spanner",
-                targetProfile:    "",
-                filePrefix:       "",
-                WriteLimit:       DefaultWritersLimit,
-                dryRun:           false,
-                logLevel:         "DEBUG",
-                SkipForeignKeys:  false,
-                validate:         false,
-                dataflowTemplate: constants.DEFAULT_TEMPLATE_PATH,
-        }
-
-        schemaAndDataCmd:= SchemaAndDataCmd{}
-        schemaAndDataCmd.SetFlags(fs)
-        assert.Equal(t, expectedValues, schemaAndDataCmd, "Invalid Log Level")
-}
-
-func TestSchemaAndDataCmd_SetFlags_EmptySourceProfile(t *testing.T) {
-        fs:= flag.NewFlagSet("testSetFlagsemptysource", flag.ContinueOnError)
-        fs.String("source", "MySQL", "")
-        fs.String("source-profile", "", "")
-
-        expectedValues:= SchemaAndDataCmd{
-                source:           "MySQL",
-                sourceProfile:    "",
-                target:           "Spanner",
-                targetProfile:    "",
-                filePrefix:       "",
-                WriteLimit:       DefaultWritersLimit,
-                dryRun:           false,
-                logLevel:         "DEBUG",
-                SkipForeignKeys:  false,
-                validate:         false,
-                dataflowTemplate: constants.DEFAULT_TEMPLATE_PATH,
-        }
-
-        schemaAndDataCmd:= SchemaAndDataCmd{}
-        schemaAndDataCmd.SetFlags(fs)
-        assert.Equal(t, expectedValues, schemaAndDataCmd, "Empty Source Profile")
 }

--- a/cmd/schema_and_data_test.go
+++ b/cmd/schema_and_data_test.go
@@ -1,3 +1,17 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package cmd
 
 import (
@@ -27,34 +41,6 @@ func TestSchemaAndDataSetFlags(t *testing.T) {
                                 logLevel:         "DEBUG",
                                 SkipForeignKeys:  false,
                                 validate:         false,
-                                dataflowTemplate: constants.DEFAULT_TEMPLATE_PATH,
-                        },
-                },
-                {
-                        testName: "Non-Default Values",
-                        flagArgs:string{
-                            "-source=MySQL",
-                            "-source-profile=file=test.sql",
-                            "-target=Spanner",
-                            "-target-profile=instance=test-instance",
-                            "-prefix=test-prefix",
-                            "-write-limit=1000",
-                            "-dry-run",
-                            "-log-level=INFO",
-                            "-skip-foreign-keys",
-                            "-validate",
-                        },
-                        expectedValues: SchemaAndDataCmd{
-                                source:           "MySQL",
-                                sourceProfile:    "file=test.sql",
-                                target:           "Spanner",
-                                targetProfile:    "instance=test-instance",
-                                filePrefix:       "test-prefix",
-                                WriteLimit:       1000,
-                                dryRun:           true,
-                                logLevel:         "INFO",
-                                SkipForeignKeys:  true,
-                                validate:         true,
                                 dataflowTemplate: constants.DEFAULT_TEMPLATE_PATH,
                         },
                 },

--- a/cmd/schema_and_data_test.go
+++ b/cmd/schema_and_data_test.go
@@ -58,52 +58,12 @@ func TestSchemaAndDataSetFlags(t *testing.T) {
                                 dataflowTemplate: constants.DEFAULT_TEMPLATE_PATH,
                         },
                 },
-                {
-                        testName: "Invalid Log Level",
-                        flagArgs:string{
-                                "-log-level=INVALID",
-                        },
-                        expectedValues: SchemaAndDataCmd{
-                                source:           "",
-                                sourceProfile:    "",
-                                target:           "Spanner",
-                                targetProfile:    "",
-                                filePrefix:       "",
-                                WriteLimit:       DefaultWritersLimit,
-                                dryRun:           false,
-                                logLevel:         "DEBUG", // Should remain at the default value
-                                SkipForeignKeys:  false,
-                                validate:         false,
-                                dataflowTemplate: constants.DEFAULT_TEMPLATE_PATH,
-                        },
-                },
-                {
-                        testName: "Empty Source Profile",
-                        flagArgs:string{
-                                "-source=MySQL",
-                                "-source-profile=",
-                        },
-                        expectedValues: SchemaAndDataCmd{
-                                source:           "MySQL",
-                                sourceProfile:    "", // Should be an empty string
-                                target:           "Spanner",
-                                targetProfile:    "",
-                                filePrefix:       "",
-                                WriteLimit:       DefaultWritersLimit,
-                                dryRun:           false,
-                                logLevel:         "DEBUG",
-                                SkipForeignKeys:  false,
-                                validate:         false,
-                                dataflowTemplate: constants.DEFAULT_TEMPLATE_PATH,
-                        },
-                },
         }
 
-        for _, tc:= range testCases { // Now it can range over testCases
+        for _, tc:= range testCases {
                 t.Run(tc.testName, func(t *testing.T) {
                         fs:= flag.NewFlagSet("testSetFlags", flag.ContinueOnError)
                         fs.Parse(tc.flagArgs)
-
                         schemaAndDataCmd:= SchemaAndDataCmd{}
                         schemaAndDataCmd.SetFlags(fs)
                         assert.Equal(t, tc.expectedValues, schemaAndDataCmd, tc.testName)

--- a/cmd/schema_and_data_test.go
+++ b/cmd/schema_and_data_test.go
@@ -32,7 +32,7 @@ func TestSchemaAndDataSetFlags(t *testing.T) {
                 },
                 {
                         testName: "Non-Default Values",
-                        flagArgs:[]string{
+                        flagArgs:string{
                             "-source=MySQL",
                             "-source-profile=file=test.sql",
                             "-target=Spanner",

--- a/cmd/schema_and_data_test.go
+++ b/cmd/schema_and_data_test.go
@@ -44,7 +44,6 @@ func TestSchemaAndDataCmd_SetFlags_DefaultValues(t *testing.T) {
 }
 
 func TestSchemaAndDataCmd_SetFlags_NonDefaultValues(t *testing.T) {
-        fs:= flag.NewFlagSet("testSetFlags", flag.ContinueOnError)
         fs.String("source", "MySQL", "")
         fs.String("source-profile", "file=test.sql", "")
         fs.String("target", "Spanner", "")
@@ -71,12 +70,12 @@ func TestSchemaAndDataCmd_SetFlags_NonDefaultValues(t *testing.T) {
         }
 
         schemaAndDataCmd:= SchemaAndDataCmd{}
+        fs:= flag.NewFlagSet("testSetFlags", flag.ContinueOnError)
         schemaAndDataCmd.SetFlags(fs)
         assert.Equal(t, expectedValues, schemaAndDataCmd, "Non-Default Values")
 }
 
 func TestSchemaAndDataCmd_SetFlags_InvalidLogLevel(t *testing.T) {
-        fs:= flag.NewFlagSet("testSetFlags", flag.ContinueOnError)
         fs.String("log-level", "INVALID", "")
 
         expectedValues:= SchemaAndDataCmd{
@@ -94,12 +93,12 @@ func TestSchemaAndDataCmd_SetFlags_InvalidLogLevel(t *testing.T) {
         }
 
         schemaAndDataCmd:= SchemaAndDataCmd{}
+        fs:= flag.NewFlagSet("testSetFlags", flag.ContinueOnError)
         schemaAndDataCmd.SetFlags(fs)
         assert.Equal(t, expectedValues, schemaAndDataCmd, "Invalid Log Level")
 }
 
 func TestSchemaAndDataCmd_SetFlags_EmptySourceProfile(t *testing.T) {
-        fs:= flag.NewFlagSet("testSetFlags", flag.ContinueOnError)
         fs.String("source", "MySQL", "")
         fs.String("source-profile", "", "")
 
@@ -118,6 +117,7 @@ func TestSchemaAndDataCmd_SetFlags_EmptySourceProfile(t *testing.T) {
         }
 
         schemaAndDataCmd:= SchemaAndDataCmd{}
+        fs:= flag.NewFlagSet("testSetFlags", flag.ContinueOnError)
         schemaAndDataCmd.SetFlags(fs)
         assert.Equal(t, expectedValues, schemaAndDataCmd, "Empty Source Profile")
 }

--- a/cmd/schema_and_data_test.go
+++ b/cmd/schema_and_data_test.go
@@ -3,19 +3,19 @@ package cmd
 import (
         "flag"
         "testing"
-
         "github.com/GoogleCloudPlatform/spanner-migration-tool/common/constants"
         "github.com/stretchr/testify/assert"
 )
 
 func TestSchemaAndDataSetFlags(t *testing.T) {
-        testCases:=struct {
+        testCases:=[]struct {
                 testName       string
                 flagArgs      string
                 expectedValues SchemaAndDataCmd
         }{
                 {
                         testName: "Default Values",
+                        flagArgs: string{},
                         expectedValues: SchemaAndDataCmd{
                                 source:           "",
                                 sourceProfile:    "",

--- a/cmd/schema_and_data_test.go
+++ b/cmd/schema_and_data_test.go
@@ -15,112 +15,109 @@
 package cmd
 
 import (
-	"flag"
-	"testing"
+        "flag"
+        "testing"
 
-	"github.com/GoogleCloudPlatform/spanner-migration-tool/common/constants"
-	"github.com/stretchr/testify/assert"
+        "github.com/GoogleCloudPlatform/spanner-migration-tool/common/constants"
+        "github.com/stretchr/testify/assert"
 )
 
-func TestSchemaAndDataSetFlags(t *testing.T) {
-	testCases:=struct {
-		testName       string
-		flagArgs      string
-		expectedValues SchemaAndDataCmd
-	}{
-		{
-			testName: "Default Values",
-			expectedValues: SchemaAndDataCmd{
-				source:           "",
-				sourceProfile:    "",
-				target:           "Spanner",
-				targetProfile:    "",
-				filePrefix:       "",
-				WriteLimit:       DefaultWritersLimit,
-				dryRun:           false,
-				logLevel:         "DEBUG",
-				SkipForeignKeys:  false,
-				validate:         false,
-				dataflowTemplate: constants.DEFAULT_TEMPLATE_PATH,
-			},
-		},
-		{
-			testName: "Non-Default Values",
-			flagArgs:string{
-				"-source=MySQL",
-				"-source-profile=file=test.sql",
-				"-target=Spanner",
-				"-target-profile=instance=test-instance",
-				"-prefix=test-prefix",
-				"-write-limit=1000",
-				"-dry-run",
-				"-log-level=INFO",
-				"-skip-foreign-keys",
-				"-validate",
-			},
-			expectedValues: SchemaAndDataCmd{
-				source:           "MySQL",
-				sourceProfile:    "file=test.sql",
-				target:           "Spanner",
-				targetProfile:    "instance=test-instance",
-				filePrefix:       "test-prefix",
-				WriteLimit:       1000,
-				dryRun:           true,
-				logLevel:         "INFO",
-				SkipForeignKeys:  true,
-				validate:         true,
-				dataflowTemplate: constants.DEFAULT_TEMPLATE_PATH,
-			},
-		},
-		{
-			testName: "Invalid Log Level",
-			flagArgs:string{
-				"-log-level=INVALID",
-			},
-			expectedValues: SchemaAndDataCmd{
-				source:           "",
-				sourceProfile:    "",
-				target:           "Spanner",
-				targetProfile:    "",
-				filePrefix:       "",
-				WriteLimit:       DefaultWritersLimit,
-				dryRun:           false,
-				logLevel:         "DEBUG",
-				SkipForeignKeys:  false,
-				validate:         false,
-				dataflowTemplate: constants.DEFAULT_TEMPLATE_PATH,
-			},
-		},
-		{
-			testName: "Empty Source Profile",
-			flagArgs:string{
-				"-source=MySQL",
-				"-source-profile=",
-			},
-			expectedValues: SchemaAndDataCmd{
-				source:           "MySQL",
-				sourceProfile:    "",
-				target:           "Spanner",
-				targetProfile:    "",
-				filePrefix:       "",
-				WriteLimit:       DefaultWritersLimit,
-				dryRun:           false,
-				logLevel:         "DEBUG",
-				SkipForeignKeys:  false,
-				validate:         false,
-				dataflowTemplate: constants.DEFAULT_TEMPLATE_PATH,
-			},
-		},
-	}
+func TestSchemaAndDataCmd_SetFlags_DefaultValues(t *testing.T) {
+        expectedValues:= SchemaAndDataCmd{
+                source:           "",
+                sourceProfile:    "",
+                target:           "Spanner",
+                targetProfile:    "",
+                filePrefix:       "",
+                WriteLimit:       DefaultWritersLimit,
+                dryRun:           false,
+                logLevel:         "DEBUG",
+                SkipForeignKeys:  false,
+                validate:         false,
+                dataflowTemplate: constants.DEFAULT_TEMPLATE_PATH,
+        }
 
-	for _, tc:= range testCases {
-		t.Run(tc.testName, func(t *testing.T) {
-			fs:= flag.NewFlagSet("testSetFlags", flag.ContinueOnError)
-			fs.Parse(tc.flagArgs)
+        schemaAndDataCmd:= SchemaAndDataCmd{}
+        fs:= flag.NewFlagSet("testSetFlags", flag.ContinueOnError)
+        schemaAndDataCmd.SetFlags(fs)
+        assert.Equal(t, expectedValues, schemaAndDataCmd, "Default Values")
+}
 
-			schemaAndDataCmd:= SchemaAndDataCmd{}
-			schemaAndDataCmd.SetFlags(fs)
-			assert.Equal(t, tc.expectedValues, schemaAndDataCmd, tc.testName)
-		})
-	}
+func TestSchemaAndDataCmd_SetFlags_NonDefaultValues(t *testing.T) {
+        fs:= flag.NewFlagSet("testSetFlags", flag.ContinueOnError)
+        fs.String("source", "MySQL", "")
+        fs.String("source-profile", "file=test.sql", "")
+        fs.String("target", "Spanner", "")
+        fs.String("target-profile", "instance=test-instance", "")
+        fs.String("prefix", "test-prefix", "")
+        fs.Int64("write-limit", 1000, "")
+        fs.Bool("dry-run", true, "")
+        fs.String("log-level", "INFO", "")
+        fs.Bool("skip-foreign-keys", true, "")
+        fs.Bool("validate", true, "")
+
+        expectedValues:= SchemaAndDataCmd{
+                source:           "MySQL",
+                sourceProfile:    "file=test.sql",
+                target:           "Spanner",
+                targetProfile:    "instance=test-instance",
+                filePrefix:       "test-prefix",
+                WriteLimit:       1000,
+                dryRun:           true,
+                logLevel:         "INFO",
+                SkipForeignKeys:  true,
+                validate:         true,
+                dataflowTemplate: constants.DEFAULT_TEMPLATE_PATH,
+        }
+
+        schemaAndDataCmd:= SchemaAndDataCmd{}
+        schemaAndDataCmd.SetFlags(fs)
+        assert.Equal(t, expectedValues, schemaAndDataCmd, "Non-Default Values")
+}
+
+func TestSchemaAndDataCmd_SetFlags_InvalidLogLevel(t *testing.T) {
+        fs:= flag.NewFlagSet("testSetFlags", flag.ContinueOnError)
+        fs.String("log-level", "INVALID", "")
+
+        expectedValues:= SchemaAndDataCmd{
+                source:           "",
+                sourceProfile:    "",
+                target:           "Spanner",
+                targetProfile:    "",
+                filePrefix:       "",
+                WriteLimit:       DefaultWritersLimit,
+                dryRun:           false,
+                logLevel:         "DEBUG",
+                SkipForeignKeys:  false,
+                validate:         false,
+                dataflowTemplate: constants.DEFAULT_TEMPLATE_PATH,
+        }
+
+        schemaAndDataCmd:= SchemaAndDataCmd{}
+        schemaAndDataCmd.SetFlags(fs)
+        assert.Equal(t, expectedValues, schemaAndDataCmd, "Invalid Log Level")
+}
+
+func TestSchemaAndDataCmd_SetFlags_EmptySourceProfile(t *testing.T) {
+        fs:= flag.NewFlagSet("testSetFlags", flag.ContinueOnError)
+        fs.String("source", "MySQL", "")
+        fs.String("source-profile", "", "")
+
+        expectedValues:= SchemaAndDataCmd{
+                source:           "MySQL",
+                sourceProfile:    "",
+                target:           "Spanner",
+                targetProfile:    "",
+                filePrefix:       "",
+                WriteLimit:       DefaultWritersLimit,
+                dryRun:           false,
+                logLevel:         "DEBUG",
+                SkipForeignKeys:  false,
+                validate:         false,
+                dataflowTemplate: constants.DEFAULT_TEMPLATE_PATH,
+        }
+
+        schemaAndDataCmd:= SchemaAndDataCmd{}
+        schemaAndDataCmd.SetFlags(fs)
+        assert.Equal(t, expectedValues, schemaAndDataCmd, "Empty Source Profile")
 }

--- a/cmd/schema_and_data_test.go
+++ b/cmd/schema_and_data_test.go
@@ -10,7 +10,7 @@ import (
 func TestSchemaAndDataSetFlags(t *testing.T) {
         testCases:=[]struct {
                 testName       string
-                flagArgs      string
+                flagArgs      []string
                 expectedValues SchemaAndDataCmd
         }{
                 {

--- a/cmd/schema_and_data_test.go
+++ b/cmd/schema_and_data_test.go
@@ -44,7 +44,7 @@ func TestSchemaAndDataCmd_SetFlags_DefaultValues(t *testing.T) {
 }
 
 func TestSchemaAndDataCmd_SetFlags_NonDefaultValues(t *testing.T) {
-        fs:= flag.NewFlagSet("testSetFlags", flag.ContinueOnError)
+        fs:= flag.NewFlagSet("testSetFlagsnondefault", flag.ContinueOnError)
         fs.String("source", "MySQL", "")
         fs.String("source-profile", "file=test.sql", "")
         fs.String("target", "Spanner", "")
@@ -76,7 +76,7 @@ func TestSchemaAndDataCmd_SetFlags_NonDefaultValues(t *testing.T) {
 }
 
 func TestSchemaAndDataCmd_SetFlags_InvalidLogLevel(t *testing.T) {
-        fs:= flag.NewFlagSet("testSetFlags", flag.ContinueOnError)
+        fs:= flag.NewFlagSet("testSetFlagsinvalidlog", flag.ContinueOnError)
         fs.String("log-level", "INVALID", "")
 
         expectedValues:= SchemaAndDataCmd{
@@ -99,7 +99,7 @@ func TestSchemaAndDataCmd_SetFlags_InvalidLogLevel(t *testing.T) {
 }
 
 func TestSchemaAndDataCmd_SetFlags_EmptySourceProfile(t *testing.T) {
-        fs:= flag.NewFlagSet("testSetFlags", flag.ContinueOnError)
+        fs:= flag.NewFlagSet("testSetFlagsemptysource", flag.ContinueOnError)
         fs.String("source", "MySQL", "")
         fs.String("source-profile", "", "")
 

--- a/cmd/schema_and_data_test.go
+++ b/cmd/schema_and_data_test.go
@@ -23,23 +23,104 @@ import (
 )
 
 func TestSchemaAndDataSetFlags(t *testing.T) {
-	testName := "Default Values"
-	expectedValues := SchemaAndDataCmd{
-		source:           "",
-		sourceProfile:    "",
-		target:           "Spanner",
-		targetProfile:    "",
-		filePrefix:       "",
-		WriteLimit:       DefaultWritersLimit,
-		dryRun:           false,
-		logLevel:         "DEBUG",
-		SkipForeignKeys:  false,
-		validate:         false,
-		dataflowTemplate: constants.DEFAULT_TEMPLATE_PATH,
+	testCases:=struct {
+		testName       string
+		flagArgs      string
+		expectedValues SchemaAndDataCmd
+	}{
+		{
+			testName: "Default Values",
+			expectedValues: SchemaAndDataCmd{
+				source:           "",
+				sourceProfile:    "",
+				target:           "Spanner",
+				targetProfile:    "",
+				filePrefix:       "",
+				WriteLimit:       DefaultWritersLimit,
+				dryRun:           false,
+				logLevel:         "DEBUG",
+				SkipForeignKeys:  false,
+				validate:         false,
+				dataflowTemplate: constants.DEFAULT_TEMPLATE_PATH,
+			},
+		},
+		{
+			testName: "Non-Default Values",
+			flagArgs:string{
+				"-source=MySQL",
+				"-source-profile=file=test.sql",
+				"-target=Spanner",
+				"-target-profile=instance=test-instance",
+				"-prefix=test-prefix",
+				"-write-limit=1000",
+				"-dry-run",
+				"-log-level=INFO",
+				"-skip-foreign-keys",
+				"-validate",
+			},
+			expectedValues: SchemaAndDataCmd{
+				source:           "MySQL",
+				sourceProfile:    "file=test.sql",
+				target:           "Spanner",
+				targetProfile:    "instance=test-instance",
+				filePrefix:       "test-prefix",
+				WriteLimit:       1000,
+				dryRun:           true,
+				logLevel:         "INFO",
+				SkipForeignKeys:  true,
+				validate:         true,
+				dataflowTemplate: constants.DEFAULT_TEMPLATE_PATH,
+			},
+		},
+		{
+			testName: "Invalid Log Level",
+			flagArgs:string{
+				"-log-level=INVALID",
+			},
+			expectedValues: SchemaAndDataCmd{
+				source:           "",
+				sourceProfile:    "",
+				target:           "Spanner",
+				targetProfile:    "",
+				filePrefix:       "",
+				WriteLimit:       DefaultWritersLimit,
+				dryRun:           false,
+				logLevel:         "DEBUG",
+				SkipForeignKeys:  false,
+				validate:         false,
+				dataflowTemplate: constants.DEFAULT_TEMPLATE_PATH,
+			},
+		},
+		{
+			testName: "Empty Source Profile",
+			flagArgs:string{
+				"-source=MySQL",
+				"-source-profile=",
+			},
+			expectedValues: SchemaAndDataCmd{
+				source:           "MySQL",
+				sourceProfile:    "",
+				target:           "Spanner",
+				targetProfile:    "",
+				filePrefix:       "",
+				WriteLimit:       DefaultWritersLimit,
+				dryRun:           false,
+				logLevel:         "DEBUG",
+				SkipForeignKeys:  false,
+				validate:         false,
+				dataflowTemplate: constants.DEFAULT_TEMPLATE_PATH,
+			},
+		},
 	}
 
-	schemaAndDataCmd := SchemaAndDataCmd{}
-	fs := flag.NewFlagSet("testSetFlags", flag.ContinueOnError)
-	schemaAndDataCmd.SetFlags(fs)
-	assert.Equal(t, expectedValues, schemaAndDataCmd, testName)
+	for _, tc:= range testCases {
+		t.Run(tc.testName, func(t *testing.T) {
+			fs:= flag.NewFlagSet("testSetFlags", flag.ContinueOnError)
+			fs.Parse(tc.flagArgs)
+
+			schemaAndDataCmd:= SchemaAndDataCmd{}
+			schemaAndDataCmd.SetFlags(fs)
+			assert.Equal(t, tc.expectedValues, schemaAndDataCmd, tc.testName)
+		})
+	}
 }


### PR DESCRIPTION
In an effort to improve test coverage relating to https://github.com/GoogleCloudPlatform/spanner-migration-tool/issues/1022, I propose the following refactoring (which will make it easier to add tests). Will add additional tests in follow up PRs. 

This refactoring is beneficial as `flag.NewFlagSet()` won't be redefined, and is consistent with other parts of the codebase. 