### PR TITLE
Update WaitGroup handling

### DIFF
--- a/common/task/task.go
+++ b/common/task/task.go
@@ -48,12 +48,12 @@ type TaskResult[O any] struct {
 // 2. Defer execution to wg.Wait(). This ensures that all tasks added to the waitGroup will be processed.
 // 3. Add len(input) tasks to the thread. This ensures that the waitGroup will track the completion of the tasks.
 // 4. We then begin the execution by executing the processAync in goroutines (equal to the numWorkers)
-// 5. When the processAsync processes a task, there are two possible outcomes - it will either pass or fail.
+// 5. When processAsync processes a task, there are two possible outcomes - it will either pass or fail.
 // 6. No matter the result, once the processing is complete, the task is acknowledged to be completed using wg.Done()
 // 7a. [If no fastExit] No matter if it passes or fails, the results are added to the TaskResult[0] array.
 // 7b. [If fastExit] Our goal here is to stop the worker pool prematurely and exit the processing. For this to happen, we need to prematurely ack the remaining tasks
 //     that are not yet done, so that wg.Wait() does not keep on definitely waiting for all the tasks to complete. Hence, we cycle through the inputChannel where we sent the
-//     work to be done and force ack all the tasks. This ensures that the waitGroup can how gracefully exit.
+//     work to be done and force ack all the remaining tasks. Note that all completed tasks would have already exited the inputChannel. This ensures that the waitGroup can how gracefully exit.
 func (rpt *RunParallelTasksImpl[I, O]) RunParallelTasks(input []I, numWorkers int, f func(i I, mutex *sync.Mutex) TaskResult[O],
 	fastExit bool) ([]TaskResult[O], error) {
 	inputChannel := make(chan I, len(input))

--- a/common/task/task.go
+++ b/common/task/task.go
@@ -60,7 +60,10 @@ func (rpt *RunParallelTasksImpl[I, O]) RunParallelTasks(input []I, numWorkers in
 	outputChannel := make(chan TaskResult[O], len(input))
 
 	wg := &sync.WaitGroup{}
-	defer wg.Wait()
+	defer func () {
+		logger.Log.Debug("waiting for all tasks to complete via wg.Wait()")
+		wg.Wait()
+	}()
 	wg.Add(len(input))
 	mutex := &sync.Mutex{}
 	logger.Log.Debug(fmt.Sprint("Number of configured workers are ", numWorkers))

--- a/common/task/task.go
+++ b/common/task/task.go
@@ -85,7 +85,9 @@ func (rpt *RunParallelTasksImpl[I, O]) RunParallelTasks(input []I, numWorkers in
 
 func processAsync[I any, O any](f func(i I, mutex *sync.Mutex) TaskResult[O], in chan I,
 	out chan TaskResult[O], mutex *sync.Mutex, wg *sync.WaitGroup) {
+	mutex.Lock()
 	wg.Add(1)
+	mutex.Unlock()
 	for i := range in {
 		logger.Log.Debug(fmt.Sprint("processing task for input", i))
 		out <- f(i, mutex)

--- a/common/task/task.go
+++ b/common/task/task.go
@@ -42,13 +42,26 @@ type TaskResult[O any] struct {
 // f:			Function to execute the task
 // fastExit: 	If an error is encountered, gracefully exit all running or queued tasks
 // Returns an array of TaskResults and last error
+// WaitGroup is used to coordinate the goroutines that are executing the input that is passed.
+// This is how we handle WaitGroup correctly - 
+// 1. Initialize waitGroup
+// 2. Defer execution to wg.Wait(). This ensures that all tasks added to the waitGroup will be processed.
+// 3. Add len(input) tasks to the thread. This ensures that the waitGroup will track the completion of the tasks.
+// 4. We then begin the execution by executing the processAync in goroutines (equal to the numWorkers)
+// 5. When the processAsync processes a task, there are two possible outcomes - it will either pass or fail.
+// 6. No matter the result, once the processing is complete, the task is acknowledged to be completed using wg.Done()
+// 7a. [If no fastExit] No matter if it passes or fails, the results are added to the TaskResult[0] array.
+// 7b. [If fastExit] Our goal here is to stop the worker pool prematurely and exit the processing. For this to happen, we need to prematurely ack the remaining tasks
+//     that are not yet done, so that wg.Wait() does not keep on definitely waiting for all the tasks to complete. Hence, we cycle through the inputChannel where we sent the
+//     work to be done and force ack all the tasks. This ensures that the waitGroup can how gracefully exit.
 func (rpt *RunParallelTasksImpl[I, O]) RunParallelTasks(input []I, numWorkers int, f func(i I, mutex *sync.Mutex) TaskResult[O],
 	fastExit bool) ([]TaskResult[O], error) {
 	inputChannel := make(chan I, len(input))
 	outputChannel := make(chan TaskResult[O], len(input))
 
 	wg := &sync.WaitGroup{}
-
+	defer wg.Wait()
+	wg.Add(len(input))
 	mutex := &sync.Mutex{}
 	logger.Log.Debug(fmt.Sprint("Number of configured workers are ", numWorkers))
 	for w := 0; w < numWorkers; w++ {
@@ -66,24 +79,22 @@ func (rpt *RunParallelTasksImpl[I, O]) RunParallelTasks(input []I, numWorkers in
 		if fastExit && res.Err != nil {
 			logger.Log.Debug(fmt.Sprint("stopping worker pool due to encountered error", res.Err))
 			for range inputChannel {
-				logger.Log.Debug(fmt.Sprint("ignoring task to fast exit"))
+				logger.Log.Debug("ignoring task to fast exit, calling wg.Done")
+				wg.Done()
 			}
-			wg.Wait()
 			return out, res.Err
 		}
 		out = append(out, res)
 	}
-	wg.Wait()
 	logger.Log.Debug(fmt.Sprintf("completed processing of %d tasks", len(out)))
 	return out, nil
 }
 
 func processAsync[I any, O any](f func(i I, mutex *sync.Mutex) TaskResult[O], in chan I,
 	out chan TaskResult[O], mutex *sync.Mutex, wg *sync.WaitGroup) {
-	wg.Add(1)
 	for i := range in {
 		logger.Log.Debug(fmt.Sprint("processing task for input", i))
 		out <- f(i, mutex)
+		wg.Done()
 	}
-	wg.Done()
 }


### PR DESCRIPTION
Fixed flaky test: b/404432832

### Investigation

This is what was happening initially, this was the error - 

`panic: sync: WaitGroup misuse: Add called concurrently with Wait`

I solved this by protecting the Add() with the mutex that is already passed to the processAsync method. When I did that, the error above went away, instead I got this error - 

`panic: sync: WaitGroup is reused before previous Wait has returned [recovered]`

From my research, the above happens when the WaitGroup is accessed while a previous Wait() is in progress.

This is when I made the fix in this PR.

My hypothesis is that whenever the fastExit is triggered, because we would call two wg.Wait(), one in the fastExit code, and the other in the defer - it can result in this concurrency issue, where the wg.Wait() from the fastExit has not returned and the wg.Wait() from the defer is triggered. 
Because fastExit code would get triggered in cases when an individual goroutine _happens_ to return an error, it would also explain the flakiness. 

I add also considered adding all the routines together as you are recommending wg.Add(n), but I found this blog which seems to suggest that doing that is error-prone. 

https://victoriametrics.com/blog/go-sync-waitgroup/#:~:text=%E2%80%9CWhy%20is%20wg.Add(n)%20considered%20error%2Dprone%3F%E2%80%9D

### Change

Currently, `wg.Wait()` is executed inside a `defer` block, which means it only executes after the RunParallelTasks function completes, regardless of how the function itself exits. In the fastExit scenario, we are explicitly calling `wg.Wait()` within the function. Later, when the function exits the `defer` block will also be triggered. This can theoretically lead to the "WaitGroup is reused before previous Wait has returned" error.
The `wg.Wait()` is now called after the loop that reads from `outputChannel`. This ensures that all workers have finished before the function returns. The deferred `wg.Wait()` has been removed.

### Testing 

1. Ran the `integration test` suite multiple items on this PR. This issue did not appear again.
2. Ran a large scale schema migration with over 1400 tables and ~1000 default and check constraints which totaled a completion of 4387 internal goroutines during processing. This test was run 2 times. No error was observed.


