### PR TITLE
Cassandra Schema Migration support for primitive types via CLI

### DIFF
--- a/accessors/cassandra/cassandra_accessor.go
+++ b/accessors/cassandra/cassandra_accessor.go
@@ -1,0 +1,67 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package cassandraaccessor
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	cc "github.com/GoogleCloudPlatform/spanner-migration-tool/accessors/clients/cassandra"
+	"github.com/GoogleCloudPlatform/spanner-migration-tool/profiles"
+)
+
+type CassandraAccessor struct {
+	client   cc.CassandraClusterInterface
+	keyspaceMetadata cc.KeyspaceMetadataInterface
+}
+
+var getOrCreateClient = cc.GetOrCreateCassandraClusterClient
+
+func NewCassandraAccessor(sourceProfile profiles.SourceProfile) (*CassandraAccessor, cc.KeyspaceMetadataInterface, error) {
+	cfg := sourceProfile.Conn.Cassandra
+
+	port, _ := strconv.Atoi(cfg.Port)
+
+	client, err := getOrCreateClient(
+		strings.Split(cfg.Host, ","),
+		port,
+		cfg.Keyspace,
+		cfg.DataCenter,
+		cfg.User,
+		cfg.Pwd,
+	)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create Cassandra client: %w", err)
+	}
+
+	keyspaceMD, err := client.KeyspaceMetadata(cfg.Keyspace)
+	if err != nil {
+		client.Close()
+		return nil, nil, fmt.Errorf("failed to retrieve keyspace metadata for '%s': %w", cfg.Keyspace, err)
+	}
+
+	accessor := &CassandraAccessor{
+		client:   client,
+		keyspaceMetadata: keyspaceMD,
+	}
+
+	return accessor, keyspaceMD, nil
+}
+
+func (acc *CassandraAccessor) Close() {
+	if acc.client != nil {
+		acc.client.Close()
+	}
+}

--- a/accessors/cassandra/cassandra_accessor_test.go
+++ b/accessors/cassandra/cassandra_accessor_test.go
@@ -1,0 +1,124 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may-obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package cassandraaccessor
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	cc "github.com/GoogleCloudPlatform/spanner-migration-tool/accessors/clients/cassandra"
+	"github.com/GoogleCloudPlatform/spanner-migration-tool/profiles"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewCassandraAccessor(t *testing.T) {
+	originalGetOrCreateClient := getOrCreateClient
+	defer func() { getOrCreateClient = originalGetOrCreateClient }()
+
+	sourceProfile := profiles.SourceProfile{
+		Conn: profiles.SourceProfileConnection{
+			Cassandra: profiles.SourceProfileConnectionCassandra{
+				Host:       "127.0.0.1",
+				Port:       "9042",
+				Keyspace:   "test_keyspace",
+				DataCenter: "dc1",
+				User:       "user",
+				Pwd:        "pass",
+			},
+		},
+	}
+
+	t.Run("Success", func(t *testing.T) {
+		mockMetadata := new(cc.MockKeyspaceMetadata)
+		mockClient := new(cc.MockCassandraCluster)
+
+		mockClient.On("KeyspaceMetadata", "test_keyspace").Return(mockMetadata, nil).Once()
+
+		getOrCreateClient = func(contactPoints []string, port int, keyspace, datacenter, user, password string) (cc.CassandraClusterInterface, error) {
+			assert.Equal(t, []string{"127.0.0.1"}, contactPoints)
+			assert.Equal(t, 9042, port)
+			assert.Equal(t, "test_keyspace", keyspace)
+			assert.Equal(t, "dc1", datacenter)
+			assert.Equal(t, "user", user)
+			assert.Equal(t, "pass", password)
+			return mockClient, nil
+		}
+
+		accessor, keyspaceMD, err := NewCassandraAccessor(sourceProfile)
+
+		assert.NoError(t, err)
+		assert.NotNil(t, accessor)
+		assert.Equal(t, mockMetadata, keyspaceMD)
+		assert.Equal(t, mockClient, accessor.client)
+		assert.Equal(t, mockMetadata, accessor.keyspaceMetadata)
+		mockClient.AssertExpectations(t)
+	})
+
+	t.Run("Failure to create client", func(t *testing.T) {
+		expectedErr := errors.New("client creation failed")
+		getOrCreateClient = func(contactPoints []string, port int, keyspace, datacenter, user, password string) (cc.CassandraClusterInterface, error) {
+			return nil, expectedErr
+		}
+
+		accessor, keyspaceMD, err := NewCassandraAccessor(sourceProfile)
+
+		assert.Nil(t, accessor)
+		assert.Nil(t, keyspaceMD)
+		assert.Error(t, err)
+		assert.True(t, errors.Is(err, expectedErr), "The original error should be wrapped")
+		assert.EqualError(t, err, fmt.Sprintf("failed to create Cassandra client: %s", expectedErr))
+	})
+
+	t.Run("Failure to get keyspace metadata", func(t *testing.T) {
+		expectedErr := errors.New("metadata retrieval failed")
+		mockClient := new(cc.MockCassandraCluster)
+
+		mockClient.On("KeyspaceMetadata", "test_keyspace").Return(nil, expectedErr).Once()
+		mockClient.On("Close").Return().Once()
+
+		getOrCreateClient = func(contactPoints []string, port int, keyspace, datacenter, user, password string) (cc.CassandraClusterInterface, error) {
+			return mockClient, nil
+		}
+
+		accessor, keyspaceMD, err := NewCassandraAccessor(sourceProfile)
+
+		assert.Nil(t, accessor)
+		assert.Nil(t, keyspaceMD)
+		assert.Error(t, err)
+		assert.True(t, errors.Is(err, expectedErr), "The original error should be wrapped")
+		assert.EqualError(t, err, fmt.Sprintf("failed to retrieve keyspace metadata for 'test_keyspace': %s", expectedErr))
+		mockClient.AssertExpectations(t)
+	})
+}
+
+func TestCassandraAccessor_Close(t *testing.T) {
+	t.Run("Closes a non-nil client", func(t *testing.T) {
+		mockClient := new(cc.MockCassandraCluster)
+		mockClient.On("Close").Return().Once()
+		accessor := &CassandraAccessor{client: mockClient}
+
+		accessor.Close()
+
+		mockClient.AssertExpectations(t)
+	})
+
+	t.Run("Does not panic with a nil client", func(t *testing.T) {
+		accessor := &CassandraAccessor{client: nil}
+		
+		assert.NotPanics(t, func() {
+			accessor.Close()
+		})
+	})
+}

--- a/accessors/clients/cassandra/cassandra_client.go
+++ b/accessors/clients/cassandra/cassandra_client.go
@@ -1,0 +1,64 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-20.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cassandraclient
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/gocql/gocql"
+)
+
+var once sync.Once
+var globalClusterConfig *gocql.ClusterConfig
+
+// newCluster is declared as a global variable for easy mocking of gocql.NewCluster during tests.
+var newCluster = gocql.NewCluster
+
+var createSessionFromCluster = func(c *gocql.ClusterConfig) (GocqlSessionInterface, error) {
+	session, err := c.CreateSession()
+	if err != nil {
+		return nil, err
+	}
+	return NewGocqlSessionImpl(session), nil
+}
+
+func GetOrCreateCassandraClusterClient(contactPoints []string, port int, keyspace, datacenter, user, password string) (CassandraClusterInterface, error) {
+	once.Do(func() {
+		clusterCfg := newCluster(contactPoints...)
+		clusterCfg.Keyspace = keyspace
+		clusterCfg.Consistency = gocql.Quorum
+		clusterCfg.Timeout = 10 * time.Second
+		clusterCfg.RetryPolicy = &gocql.SimpleRetryPolicy{NumRetries: 3}
+		if port > 0 {
+			clusterCfg.Port = port
+		}
+		if user != "" {
+			clusterCfg.Authenticator = gocql.PasswordAuthenticator{Username: user, Password: password}
+		}
+		if datacenter != "" {
+			clusterCfg.PoolConfig.HostSelectionPolicy = gocql.DCAwareRoundRobinPolicy(datacenter)
+		}
+		globalClusterConfig = clusterCfg
+	})
+
+	wrappedSession, err := createSessionFromCluster(globalClusterConfig)
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to create Cassandra session: %w", err)
+	}
+	return &CassandraClusterImpl{session: wrappedSession}, nil
+}

--- a/accessors/clients/cassandra/cassandra_client_test.go
+++ b/accessors/clients/cassandra/cassandra_client_test.go
@@ -1,0 +1,132 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package cassandraclient
+
+import (
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gocql/gocql"
+	"github.com/stretchr/testify/assert"
+)
+
+func resetGlobals() {
+	once = sync.Once{}
+	globalClusterConfig = nil
+}
+
+func TestGetOrCreateCassandraClusterClient(t *testing.T) {
+	originalCreateSession := createSessionFromCluster
+	originalNewCluster := newCluster
+	defer func() {
+		createSessionFromCluster = originalCreateSession
+		newCluster = originalNewCluster
+		resetGlobals()
+	}()
+
+	t.Run("Success on first call with basic config", func(t *testing.T) {
+		resetGlobals()
+		var capturedClusterConfig *gocql.ClusterConfig
+
+		newCluster = func(contactPoints ...string) *gocql.ClusterConfig {
+			cfg := gocql.NewCluster(contactPoints...)
+			capturedClusterConfig = cfg
+			return cfg
+		}
+
+		mockSession := &MockGocqlSession{}
+		createSessionFromCluster = func(c *gocql.ClusterConfig) (GocqlSessionInterface, error) {
+			return mockSession, nil
+		}
+
+		client, err := GetOrCreateCassandraClusterClient([]string{"127.0.0.1"}, 0, "test_keyspace", "", "", "")
+
+		assert.NoError(t, err)
+		assert.NotNil(t, client)
+		assert.NotNil(t, globalClusterConfig)
+		assert.Equal(t, "test_keyspace", capturedClusterConfig.Keyspace)
+		assert.Equal(t, gocql.Quorum, capturedClusterConfig.Consistency)
+		assert.Equal(t, 10*time.Second, capturedClusterConfig.Timeout)
+		assert.IsType(t, &gocql.SimpleRetryPolicy{}, capturedClusterConfig.RetryPolicy)
+		assert.Equal(t, 3, capturedClusterConfig.RetryPolicy.(*gocql.SimpleRetryPolicy).NumRetries)
+		assert.Nil(t, capturedClusterConfig.Authenticator)
+	})
+
+	t.Run("Success on first call with full config", func(t *testing.T) {
+		resetGlobals()
+		var capturedClusterConfig *gocql.ClusterConfig
+
+		newCluster = func(contactPoints ...string) *gocql.ClusterConfig {
+			cfg := gocql.NewCluster(contactPoints...)
+			capturedClusterConfig = cfg
+			return cfg
+		}
+		mockSession := &MockGocqlSession{}
+		createSessionFromCluster = func(c *gocql.ClusterConfig) (GocqlSessionInterface, error) {
+			return mockSession, nil
+		}
+
+		client, err := GetOrCreateCassandraClusterClient([]string{"127.0.0.1"}, 9042, "ks", "dc1", "user", "pass")
+
+		assert.NoError(t, err)
+		assert.NotNil(t, client)
+		assert.Equal(t, 9042, capturedClusterConfig.Port)
+		assert.NotNil(t, capturedClusterConfig.PoolConfig.HostSelectionPolicy)
+		assert.IsType(t, gocql.DCAwareRoundRobinPolicy(""), capturedClusterConfig.PoolConfig.HostSelectionPolicy)
+		expectedAuth := gocql.PasswordAuthenticator{Username: "user", Password: "pass"}
+		assert.Equal(t, expectedAuth, capturedClusterConfig.Authenticator)
+	})
+
+	t.Run("Failure on session creation", func(t *testing.T) {
+		resetGlobals()
+		expectedErr := errors.New("session creation failed")
+		createSessionFromCluster = func(c *gocql.ClusterConfig) (GocqlSessionInterface, error) {
+			return nil, expectedErr
+		}
+
+		client, err := GetOrCreateCassandraClusterClient([]string{"127.0.0.1"}, 9042, "ks", "", "", "")
+
+		assert.Nil(t, client)
+		assert.Error(t, err)
+		assert.True(t, errors.Is(err, expectedErr))
+		assert.EqualError(t, err, "failed to create Cassandra session: session creation failed")
+	})
+
+}
+
+func TestGetOrCreateCassandraClusterClientSingleton(t *testing.T) {
+	var newClusterCallCount int
+	resetGlobals()
+
+	originalNewCluster := newCluster
+	newCluster = func(cp ...string) *gocql.ClusterConfig {
+		newClusterCallCount++
+		return gocql.NewCluster(cp...)
+	}
+	t.Cleanup(func() { newCluster = originalNewCluster })
+
+	_, _ = GetOrCreateCassandraClusterClient([]string{"host1"}, 9042, "keyspace1", "dc1", "user1", "pass1")
+	_, _ = GetOrCreateCassandraClusterClient([]string{"host2"}, 9043, "keyspace2", "dc2", "user2", "pass2")
+	_, _ = GetOrCreateCassandraClusterClient([]string{"host3"}, 9044, "keyspace3", "dc3", "user3", "pass3")
+
+
+	assert.Equal(t, 1, newClusterCallCount, "The cluster config should only be initialized once.")
+	assert.NotNil(t, globalClusterConfig)
+	assert.Equal(t, []string{"host1"}, globalClusterConfig.Hosts)
+	assert.Equal(t, 9042, globalClusterConfig.Port)
+	assert.Equal(t, "keyspace1", globalClusterConfig.Keyspace)
+	assert.Equal(t, gocql.PasswordAuthenticator{Username: "user1", Password: "pass1"}, globalClusterConfig.Authenticator)	
+}

--- a/accessors/clients/cassandra/interface.go
+++ b/accessors/clients/cassandra/interface.go
@@ -1,0 +1,87 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package cassandraclient
+
+import (
+	"fmt"
+	"github.com/gocql/gocql"
+)
+
+type GocqlSessionInterface interface {
+	KeyspaceMetadata(keyspace string) (*gocql.KeyspaceMetadata, error)
+	Close()
+}
+
+type KeyspaceMetadataInterface interface {
+	Tables() map[string]*gocql.TableMetadata
+}
+
+type CassandraClusterInterface interface {
+	KeyspaceMetadata(keyspace string) (KeyspaceMetadataInterface, error)
+	Close() 
+}
+
+type GocqlSessionImpl struct {
+	session *gocql.Session
+}
+
+func NewGocqlSessionImpl(session *gocql.Session) *GocqlSessionImpl {
+	return &GocqlSessionImpl{session: session}
+}
+
+func (gs *GocqlSessionImpl) KeyspaceMetadata(keyspace string) (*gocql.KeyspaceMetadata, error) {
+	ks, err := gs.session.KeyspaceMetadata(keyspace)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get keyspace metadata for %s: %w", keyspace, err)
+	}
+	if ks == nil {
+		return nil, fmt.Errorf("keyspace %s not found in cluster metadata", keyspace)
+	}
+	return ks, nil
+}
+
+func (gs *GocqlSessionImpl) Close() {
+	if gs.session != nil {
+		gs.session.Close()
+	}
+}
+
+type CassandraKeyspaceMetadataImpl struct {
+	keyspaceMetadata *gocql.KeyspaceMetadata
+}
+
+func (c *CassandraKeyspaceMetadataImpl) Tables() map[string]*gocql.TableMetadata {
+	return c.keyspaceMetadata.Tables
+}
+
+type CassandraClusterImpl struct {
+	session GocqlSessionInterface
+}
+
+func (c *CassandraClusterImpl) KeyspaceMetadata(keyspace string) (KeyspaceMetadataInterface, error) {
+	ks, err := c.session.KeyspaceMetadata(keyspace)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get keyspace metadata for %s: %w", keyspace, err)
+	}
+	if ks == nil {
+		return nil, fmt.Errorf("keyspace %s not found in cluster metadata", keyspace)
+	}
+	return &CassandraKeyspaceMetadataImpl{keyspaceMetadata: ks}, nil
+}
+
+func (c *CassandraClusterImpl) Close() {
+	c.session.Close()
+}
+
+

--- a/accessors/clients/cassandra/interface_test.go
+++ b/accessors/clients/cassandra/interface_test.go
@@ -1,0 +1,108 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package cassandraclient
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/gocql/gocql"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCassandraClusterImpl(t *testing.T) {
+	t.Run("KeyspaceMetadata Success", func(t *testing.T) {
+		mockSession := new(MockGocqlSession)
+		expectedMetadata := &gocql.KeyspaceMetadata{Name: "testks"}
+		mockSession.On("KeyspaceMetadata", "testks").Return(expectedMetadata, nil).Once()
+
+		clusterImpl := &CassandraClusterImpl{session: mockSession}
+		keyspaceMeta, err := clusterImpl.KeyspaceMetadata("testks")
+
+		assert.NoError(t, err)
+		assert.NotNil(t, keyspaceMeta)
+		impl, ok := keyspaceMeta.(*CassandraKeyspaceMetadataImpl)
+		assert.True(t, ok)
+		assert.Equal(t, expectedMetadata, impl.keyspaceMetadata)
+		mockSession.AssertExpectations(t)
+	})
+
+	t.Run("KeyspaceMetadata Error DB", func(t *testing.T) {
+		mockSession := new(MockGocqlSession)
+		expectedErr := errors.New("database connection failed")
+		mockSession.On("KeyspaceMetadata", "testks").Return(nil, expectedErr).Once()
+
+		clusterImpl := &CassandraClusterImpl{session: mockSession}
+		keyspaceMeta, err := clusterImpl.KeyspaceMetadata("testks")
+
+		assert.Nil(t, keyspaceMeta)
+		assert.Error(t, err)
+		assert.True(t, errors.Is(err, expectedErr))
+		assert.EqualError(t, err, fmt.Sprintf("failed to get keyspace metadata for testks: %s", expectedErr))
+		mockSession.AssertExpectations(t)
+	})
+
+	t.Run("KeyspaceMetadata Error No Keyspace", func(t *testing.T) {
+		mockSession := new(MockGocqlSession)
+		mockSession.On("KeyspaceMetadata", "testks").Return(nil, nil).Once()
+
+		clusterImpl := &CassandraClusterImpl{session: mockSession}
+		meta, err := clusterImpl.KeyspaceMetadata("testks")
+
+		assert.Nil(t, meta)
+		assert.Error(t, err)
+		assert.EqualError(t, err, "keyspace testks not found in cluster metadata")
+
+		mockSession.AssertExpectations(t)
+	})
+
+	t.Run("Close", func(t *testing.T) {
+		mockSession := new(MockGocqlSession)
+		mockSession.On("Close").Return().Once()
+		clusterImpl := &CassandraClusterImpl{session: mockSession}
+		clusterImpl.Close()
+		mockSession.AssertExpectations(t)
+	})
+}
+
+func TestCassandraKeyspaceMetadataImpl(t *testing.T) {
+	t.Run("Tables", func(t *testing.T) {
+		expectedTables := map[string]*gocql.TableMetadata{
+			"table1": {Name: "table1"},
+		}
+		keyspaceMeta := &gocql.KeyspaceMetadata{Tables: expectedTables}
+		metaImpl := &CassandraKeyspaceMetadataImpl{keyspaceMetadata: keyspaceMeta}
+		actualTables := metaImpl.Tables()
+		assert.Equal(t, expectedTables, actualTables)
+	})
+}
+
+func TestGocqlSessionImpl(t *testing.T) {
+	t.Run("NewGocqlSessionImpl", func(t *testing.T) {
+		var s *gocql.Session 
+		impl := NewGocqlSessionImpl(s)
+		assert.NotNil(t, impl)
+		assert.Equal(t, s, impl.session)
+	})
+
+	t.Run("Close", func(t *testing.T) {
+		var mockSession *gocql.Session
+		mockSession = &gocql.Session{}
+		impl := &GocqlSessionImpl{session: mockSession}
+		assert.NotPanics(t, func() {
+			impl.Close()
+		})
+	})
+}

--- a/accessors/clients/cassandra/mocks.go
+++ b/accessors/clients/cassandra/mocks.go
@@ -1,0 +1,88 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package cassandraclient
+
+import (
+	"github.com/gocql/gocql"
+	"github.com/stretchr/testify/mock"
+)
+
+type MockGocqlSession struct {
+	mock.Mock
+}
+
+func (m *MockGocqlSession) KeyspaceMetadata(keyspace string) (*gocql.KeyspaceMetadata, error) {
+	args := m.Called(keyspace)
+	if md, ok := args.Get(0).(*gocql.KeyspaceMetadata); ok {
+		return md, args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+
+func (m *MockGocqlSession) Close() {
+	m.Called()
+}
+
+type MockKeyspaceMetadata struct {
+	mock.Mock
+	MockTables map[string]*gocql.TableMetadata
+}
+
+func (m *MockKeyspaceMetadata) Tables() map[string]*gocql.TableMetadata {
+	args := m.Called()
+	if tables, ok := args.Get(0).(map[string]*gocql.TableMetadata); ok {
+		return tables
+	}
+	return m.MockTables
+}
+
+type MockCassandraCluster struct {
+	mock.Mock
+}
+
+func (m *MockCassandraCluster) KeyspaceMetadata(keyspace string) (KeyspaceMetadataInterface, error) {
+	args := m.Called(keyspace)
+	if md, ok := args.Get(0).(KeyspaceMetadataInterface); ok {
+		return md, args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+
+func (m *MockCassandraCluster) Close() {
+	m.Called()
+}
+
+// MockTypeInfo mocks TypeInfo field in ColumnMetadata
+type MockTypeInfo struct {
+	MockGocqlType gocql.Type 
+	MockVersion   byte       
+	MockNewResult interface{}
+	MockNewError  error
+}
+
+func (m MockTypeInfo) Type() gocql.Type {
+	return m.MockGocqlType
+}
+func (m MockTypeInfo) Version() byte {
+	return m.MockVersion
+}
+func (m MockTypeInfo) Custom() string {
+	return "" 
+}
+func (m MockTypeInfo) New() interface{} {
+	return m.MockNewResult
+}
+func (m MockTypeInfo) NewWithError() (interface{}, error) {
+	return m.MockNewResult, m.MockNewError
+}

--- a/common/constants/constants.go
+++ b/common/constants/constants.go
@@ -44,6 +44,9 @@ const (
 	// This is an experimental driver; implementation in progress.
 	ORACLE string = "oracle"
 
+	// CASSANDRA is the driver name for Cassandra.
+	CASSANDRA string = "cassandra"
+
 	// Target db for which schema is being generated.
 	// This can be removed once the support for global flags is removed.
 	TargetSpanner              string = "spanner"

--- a/conversion/conversion.go
+++ b/conversion/conversion.go
@@ -77,7 +77,7 @@ type ConvImpl struct{}
 // The SourceProfile param provides the connection details to use the go SQL library.
 func (ci *ConvImpl) SchemaConv(migrationProjectId string, sourceProfile profiles.SourceProfile, targetProfile profiles.TargetProfile, ioHelper *utils.IOStreams, schemaFromSource SchemaFromSourceInterface) (*internal.Conv, error) {
 	switch sourceProfile.Driver {
-	case constants.POSTGRES, constants.MYSQL, constants.DYNAMODB, constants.SQLSERVER, constants.ORACLE:
+	case constants.POSTGRES, constants.MYSQL, constants.DYNAMODB, constants.SQLSERVER, constants.ORACLE, constants.CASSANDRA:
 		return schemaFromSource.schemaFromDatabase(migrationProjectId, sourceProfile, targetProfile, &GetInfoImpl{}, &common.ProcessSchemaImpl{})
 	case constants.PGDUMP, constants.MYSQLDUMP:
 		expressionVerificationAccessor, _ := expressions_api.NewExpressionVerificationAccessorImpl(context.Background(), targetProfile.Conn.Sp.Project, targetProfile.Conn.Sp.Instance)

--- a/conversion/conversion_helper.go
+++ b/conversion/conversion_helper.go
@@ -163,6 +163,9 @@ func ConnectionConfig(sourceProfile profiles.SourceProfile) (interface{}, error)
 		return profiles.GetSQLConnectionStr(sourceProfile), nil
 	case constants.ORACLE:
 		return profiles.GetSQLConnectionStr(sourceProfile), nil
+	// Returns an empty string as Cassandra connections are managed directly by the gocql session.	
+	case constants.CASSANDRA:
+		return "", nil
 	default:
 		return "", fmt.Errorf("driver %s not supported", sourceProfile.Driver)
 	}

--- a/conversion/get_info.go
+++ b/conversion/get_info.go
@@ -22,9 +22,11 @@ import (
 	"strings"
 
 	"cloud.google.com/go/cloudsqlconn"
+	ca "github.com/GoogleCloudPlatform/spanner-migration-tool/accessors/cassandra" 
 	"github.com/GoogleCloudPlatform/spanner-migration-tool/common/constants"
 	"github.com/GoogleCloudPlatform/spanner-migration-tool/common/utils"
 	"github.com/GoogleCloudPlatform/spanner-migration-tool/profiles"
+	"github.com/GoogleCloudPlatform/spanner-migration-tool/sources/cassandra"
 	"github.com/GoogleCloudPlatform/spanner-migration-tool/sources/common"
 	"github.com/GoogleCloudPlatform/spanner-migration-tool/sources/dynamodb"
 	"github.com/GoogleCloudPlatform/spanner-migration-tool/sources/mysql"
@@ -197,6 +199,16 @@ func (gi *GetInfoImpl) GetInfoSchema(migrationProjectId string, sourceProfile pr
 			return nil, err
 		}
 		return oracle.InfoSchemaImpl{DbName: strings.ToUpper(dbName), Db: db, MigrationProjectId: migrationProjectId, SourceProfile: sourceProfile, TargetProfile: targetProfile}, nil
+	case constants.CASSANDRA:
+		_, ksMetadata, err := ca.NewCassandraAccessor(sourceProfile)
+		if err != nil {
+			return nil, err
+		}
+		return cassandra.InfoSchemaImpl{
+			KeyspaceMetadata: ksMetadata, 
+			SourceProfile:    sourceProfile,
+			TargetProfile:    targetProfile,
+		}, nil
 	default:
 		return nil, fmt.Errorf("driver %s not supported", driver)
 	}

--- a/sources/cassandra/infoschema.go
+++ b/sources/cassandra/infoschema.go
@@ -1,0 +1,258 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cassandra
+
+import (
+	"context"
+	"fmt"
+
+	sp "cloud.google.com/go/spanner"
+	cc "github.com/GoogleCloudPlatform/spanner-migration-tool/accessors/clients/cassandra"
+	"github.com/GoogleCloudPlatform/spanner-migration-tool/internal"
+	"github.com/GoogleCloudPlatform/spanner-migration-tool/profiles"
+	"github.com/GoogleCloudPlatform/spanner-migration-tool/schema"
+	"github.com/GoogleCloudPlatform/spanner-migration-tool/sources/common"
+	"github.com/GoogleCloudPlatform/spanner-migration-tool/spanner/ddl"
+	"github.com/gocql/gocql"
+)
+
+// InfoSchemaImpl is Cassandra specific implementation for InfoSchema
+type InfoSchemaImpl struct {
+	KeyspaceMetadata cc.KeyspaceMetadataInterface
+	SourceProfile    profiles.SourceProfile
+	TargetProfile    profiles.TargetProfile
+}
+
+// GetToDdl implements the common.InfoSchema interface
+func (isi InfoSchemaImpl) GetToDdl() common.ToDdl {
+	return ToDdlImpl{
+		typeMapper: NewCassandraTypeMapper(),
+	}
+}
+
+// GetTableName returns table name
+func (isi InfoSchemaImpl) GetTableName(schema string, tableName string) string {
+	return tableName
+}
+
+// getTableMetadata returns metadata assosiated with specific table
+func (isi InfoSchemaImpl) getTableMetadata(tableName string) (*gocql.TableMetadata, bool) {
+	if isi.KeyspaceMetadata == nil {
+		return nil, false
+	}
+	for _, tm := range isi.KeyspaceMetadata.Tables() {
+		if tm.Name == tableName {
+			return tm, true
+		}
+	}
+	return nil, false
+}
+
+// GetTables return list of tables in selected keyspace
+func (isi InfoSchemaImpl) GetTables() ([]common.SchemaAndName, error) {
+	if isi.KeyspaceMetadata == nil {
+		return nil, fmt.Errorf("keyspace metadata not initialized")
+	}
+
+	tableMetas := isi.KeyspaceMetadata.Tables()
+	if len(tableMetas) == 0 {
+		return nil, fmt.Errorf("no tables found in keyspace '%s'", isi.SourceProfile.Conn.Cassandra.Keyspace)
+	}
+
+	var tables []common.SchemaAndName
+	keyspace := isi.SourceProfile.Conn.Cassandra.Keyspace
+	for _, tableMeta := range tableMetas {
+		tables = append(tables, common.SchemaAndName{Schema: keyspace, Name: tableMeta.Name})
+	}
+	return tables, nil
+}
+
+// getTypeString is a helper function to get collection types as string
+func getTypeString(typeInfo gocql.TypeInfo) (string, error) {
+	switch typeInfo.Type() {
+	case gocql.TypeSet:
+		collectionInfo, ok := typeInfo.(gocql.CollectionType)
+		if !ok {
+			return "", fmt.Errorf("invalid set type")
+		}
+		elemType, err := getTypeString(collectionInfo.Elem)
+		if err != nil {
+			return "", err
+		}
+		return fmt.Sprintf("set<%s>", elemType), nil
+
+	case gocql.TypeList:
+		collectionInfo, ok := typeInfo.(gocql.CollectionType)
+		if !ok {
+			return "", fmt.Errorf("invalid list type")
+		}
+		elemType, err := getTypeString(collectionInfo.Elem)
+		if err != nil {
+			return "", err
+		}
+		return fmt.Sprintf("list<%s>", elemType), nil
+
+	case gocql.TypeMap:
+		collectionInfo, ok := typeInfo.(gocql.CollectionType)
+		if !ok {
+			return "", fmt.Errorf("invalid map type")
+		}
+		keyType, errKey := getTypeString(collectionInfo.Key)
+		if errKey != nil {
+			return "", errKey
+		}
+		valueType, errVal := getTypeString(collectionInfo.Elem)
+		if errVal != nil {
+			return "", errVal
+		}
+		return fmt.Sprintf("map<%s,%s>", keyType, valueType), nil
+
+	default:
+		return typeInfo.Type().String(), nil
+	}
+}
+
+// GetColumns returns a list of Column objects and names
+func (isi InfoSchemaImpl) GetColumns(conv *internal.Conv, table common.SchemaAndName, constraints map[string][]string, primaryKeys []string) (map[string]schema.Column, []string, error) {
+	if isi.KeyspaceMetadata == nil {
+		return nil, nil, fmt.Errorf("keyspace metadata not initialized")
+	}
+
+	tableMetadata, ok := isi.getTableMetadata(table.Name)
+	if !ok {
+		return nil, nil, fmt.Errorf("table '%s' not found in keyspace metadata", table.Name)
+	}
+
+	colDefs := make(map[string]schema.Column)
+	var colIds []string
+
+	pkCols := make(map[string]bool)
+	for _, pkCol := range tableMetadata.PartitionKey {
+		pkCols[pkCol.Name] = true
+	}
+	for _, ckCol := range tableMetadata.ClusteringColumns {
+		pkCols[ckCol.Name] = true
+	}
+
+	for _, colMeta := range tableMetadata.Columns {
+		colId := internal.GenerateColumnId()
+		isPrimaryKey := pkCols[colMeta.Name]
+
+		colType, err := getTypeString(colMeta.Type)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		c := schema.Column{
+			Id:      colId,
+			Name:    colMeta.Name,
+			Type:    schema.Type{Name: colType},
+			NotNull: isPrimaryKey,
+			Ignored: schema.Ignored{},
+		}
+		colDefs[colId] = c
+		colIds = append(colIds, colId)
+	}
+	return colDefs, colIds, nil
+}
+
+// GetConstraints returns a list of primary keys for a given table.
+// Cassandra does not have check constraints and other constraints in the SQL sense.
+func (isi InfoSchemaImpl) GetConstraints(conv *internal.Conv, table common.SchemaAndName) ([]string, []schema.CheckConstraint, map[string][]string, error) {
+	if isi.KeyspaceMetadata == nil {
+		return nil, nil, nil, fmt.Errorf("keyspace metadata not initialized")
+	}
+
+	tableMetadata, ok := isi.getTableMetadata(table.Name)
+	if !ok {
+		return nil, nil, nil, fmt.Errorf("table '%s' not found in keyspace metadata", table.Name)
+	}
+
+	var primaryKeys []string
+
+	for _, colMeta := range tableMetadata.PartitionKey {
+		primaryKeys = append(primaryKeys, colMeta.Name)
+	}
+
+	for _, colMeta := range tableMetadata.ClusteringColumns {
+		primaryKeys = append(primaryKeys, colMeta.Name)
+	}
+
+	return primaryKeys, nil, make(map[string][]string), nil
+}
+
+// GetForeignKeys returns an empty list as Cassandra does not have foreign keys.
+func (isi InfoSchemaImpl) GetForeignKeys(conv *internal.Conv, table common.SchemaAndName) ([]schema.ForeignKey, error) {
+	return nil, nil
+}
+
+// TODO: gocql driver does not currently populate ColumnIndexMetadata in ColumnMetadata.
+// GetIndexes returns a list of secondary indexes for a given table.
+func (isi InfoSchemaImpl) GetIndexes(conv *internal.Conv, table common.SchemaAndName, colNameIdMap map[string]string) ([]schema.Index, error) {
+	if isi.KeyspaceMetadata == nil {
+		return nil, fmt.Errorf("keyspace metadata not initialized")
+	}
+
+	tableMetadata, ok := isi.getTableMetadata(table.Name)
+	if !ok {
+		return nil, fmt.Errorf("table '%s' not found in keyspace metadata", table.Name)
+	}
+	
+	var indexes []schema.Index
+	for _, colMeta := range tableMetadata.Columns {
+		if colMeta.Index.Name != "" {
+			indexMeta := colMeta.Index
+			targetColumn := colMeta.Name
+
+			spIndex := schema.Index{
+				Id:     internal.GenerateIndexesId(),
+				Name:   indexMeta.Name,
+				Unique: false,
+				Keys: []schema.Key{
+					{
+						ColId: colNameIdMap[targetColumn],
+					},
+				},
+			}
+			indexes = append(indexes, spIndex)
+		}
+	}
+
+	return indexes, nil
+}
+
+// Data Migration Related Methods (Stubs for Schema Migration)
+
+var errNotSupported = fmt.Errorf("operation not supported")
+
+func (isi InfoSchemaImpl) GetRowsFromTable(conv *internal.Conv, tableId string) (interface{}, error) {
+	return nil, errNotSupported
+}
+
+func (isi InfoSchemaImpl) GetRowCount(table common.SchemaAndName) (int64, error) {
+	return 0, errNotSupported
+}
+
+func (isi InfoSchemaImpl) ProcessData(conv *internal.Conv, tableId string, srcSchema schema.Table, spCols []string, spSchema ddl.CreateTable, additionalAttributes internal.AdditionalDataAttributes) error {
+	return errNotSupported
+}
+
+func (isi InfoSchemaImpl) StartChangeDataCapture(ctx context.Context, conv *internal.Conv) (map[string]interface{}, error) {
+	return nil, errNotSupported
+}
+
+func (isi InfoSchemaImpl) StartStreamingMigration(ctx context.Context, migrationProjectId string, client *sp.Client, conv *internal.Conv, streamInfo map[string]interface{}) (internal.DataflowOutput, error) {
+	return internal.DataflowOutput{}, errNotSupported
+}

--- a/sources/cassandra/infoschema_test.go
+++ b/sources/cassandra/infoschema_test.go
@@ -1,0 +1,417 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package cassandra
+
+import (
+	"context"
+	"sort"
+	"testing"
+
+	cc "github.com/GoogleCloudPlatform/spanner-migration-tool/accessors/clients/cassandra"
+	"github.com/GoogleCloudPlatform/spanner-migration-tool/internal"
+	"github.com/GoogleCloudPlatform/spanner-migration-tool/profiles"
+	"github.com/GoogleCloudPlatform/spanner-migration-tool/schema"
+	"github.com/GoogleCloudPlatform/spanner-migration-tool/sources/common"
+	"github.com/GoogleCloudPlatform/spanner-migration-tool/spanner/ddl"
+	"github.com/gocql/gocql"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetToDdl(t *testing.T) {
+	isi := InfoSchemaImpl{}
+	assert.IsType(t, ToDdlImpl{}, isi.GetToDdl())
+}
+
+func TestGetTableName(t *testing.T) {
+	isi := InfoSchemaImpl{}
+	actual := isi.GetTableName("some_schema", "my_table")
+	assert.Equal(t, "my_table", actual)
+}
+
+func TestGetTableMetadata(t *testing.T) {
+	mockKeyspace := &cc.MockKeyspaceMetadata{}
+	tables := map[string]*gocql.TableMetadata{
+		"table1": {Name: "table1"},
+		"table2": {Name: "table2"},
+	}
+	mockKeyspace.On("Tables").Return(tables)
+
+	isi := InfoSchemaImpl{
+		KeyspaceMetadata: mockKeyspace,
+	}
+	// Test Case 1: Table exists
+	meta, found := isi.getTableMetadata("table1")
+	assert.True(t, found, "Expected to find table 'table1'")
+	assert.NotNil(t, meta)
+	if meta != nil {
+		assert.Equal(t, "table1", meta.Name)
+	}
+	// Test Case 2: Table not found
+	_, found = isi.getTableMetadata("table3")
+	assert.False(t, found, "Expected not to find table 'table3'")
+	// Test Case 3: nil Keyspace
+	isi = InfoSchemaImpl{
+		KeyspaceMetadata: nil,
+	}
+	_, ok := isi.getTableMetadata("table1")
+	assert.False(t, ok)
+	mockKeyspace.AssertExpectations(t)
+}
+
+func TestGetTables(t *testing.T) {
+	mockKeyspace := &cc.MockKeyspaceMetadata{}
+	tables := map[string]*gocql.TableMetadata{
+		"table_c": {Name: "table_c"},
+		"table_a": {Name: "table_a"},
+		"table_b": {Name: "table_b"},
+	}
+	mockKeyspace.On("Tables").Return(tables)
+
+	isi := InfoSchemaImpl{
+		KeyspaceMetadata: mockKeyspace,
+		SourceProfile: profiles.SourceProfile{
+			Conn: profiles.SourceProfileConnection{
+				Cassandra: profiles.SourceProfileConnectionCassandra{Keyspace: "testkeyspace"},
+			},
+		},
+	}
+	actual, err := isi.GetTables()
+
+	assert.NoError(t, err)
+	expected := []common.SchemaAndName{
+		{Schema: "testkeyspace", Name: "table_a"},
+		{Schema: "testkeyspace", Name: "table_b"},
+		{Schema: "testkeyspace", Name: "table_c"},
+	}
+
+	sort.Slice(actual, func(i, j int) bool { return actual[i].Name < actual[j].Name })
+	sort.Slice(expected, func(i, j int) bool { return expected[i].Name < expected[j].Name })
+	// Test Case 1: Returns existing tables
+	assert.Equal(t, expected, actual)
+	// Test Case 2: No tables in Keyspace
+	mockKeyspace = &cc.MockKeyspaceMetadata{}
+	mockKeyspace.On("Tables").Return(map[string]*gocql.TableMetadata{})
+	isi = InfoSchemaImpl{
+		KeyspaceMetadata: mockKeyspace,
+	}
+	_, err = isi.GetTables()
+	assert.Error(t, err)
+	assert.EqualError(t, err, "no tables found in keyspace ''")
+	// Test Case 3: nil Keyspace
+	isi = InfoSchemaImpl{
+		KeyspaceMetadata: nil,
+	}
+	_, err = isi.GetTables()
+	assert.Error(t, err)
+	assert.EqualError(t, err, "keyspace metadata not initialized")
+	mockKeyspace.AssertExpectations(t)
+}
+
+
+func TestGetTypeString(t *testing.T) {
+	tests := []struct {
+		name     string
+		typeInfo gocql.TypeInfo 
+		expected string
+	}{
+		{
+			name:     "Basic Int Type",
+			typeInfo: gocql.NewNativeType(0, gocql.TypeInt, ""),
+			expected: "int",
+		},
+		{
+			name:     "Set of Int",
+			typeInfo: gocql.CollectionType{ 
+				NativeType: gocql.NewNativeType(0, gocql.TypeSet, ""),
+				Elem:       gocql.NewNativeType(0, gocql.TypeInt, ""),
+			},
+			expected: "set<int>",
+		},
+		{
+			name:     "List of Text",
+			typeInfo: gocql.CollectionType{
+				NativeType: gocql.NewNativeType(0, gocql.TypeList, ""),
+				Elem:       gocql.NewNativeType(0, gocql.TypeText, ""),
+			},
+			expected: "list<text>",
+		},
+		{
+			name:     "Map of UUID to BigInt",
+			typeInfo: gocql.CollectionType{
+				NativeType: gocql.NewNativeType(0, gocql.TypeMap, ""),
+				Key:        gocql.NewNativeType(0, gocql.TypeUUID, ""),
+				Elem:       gocql.NewNativeType(0, gocql.TypeBigInt, ""),
+			},
+			expected: "map<uuid,bigint>",
+		},
+		{
+			name:     "List of Maps of Int to Text",
+			typeInfo: gocql.CollectionType{
+				NativeType: gocql.NewNativeType(0, gocql.TypeList, ""),
+				Elem: gocql.CollectionType{
+					NativeType: gocql.NewNativeType(0, gocql.TypeMap, ""),
+					Key:        gocql.NewNativeType(0, gocql.TypeInt, ""),
+					Elem:       gocql.NewNativeType(0, gocql.TypeText, ""),
+				},
+			},
+			expected: "list<map<int,text>>",
+		},
+		{
+			name:     "TypeSet fallback",
+			typeInfo: gocql.NewNativeType(0, gocql.TypeSet, ""), 
+			expected: "",
+		},
+		{
+			name:     "TypeList fallback",
+			typeInfo: gocql.NewNativeType(0, gocql.TypeList, ""), 
+			expected: "",
+		},
+		{
+			name:     "TypeMap fallback",
+			typeInfo: gocql.NewNativeType(0, gocql.TypeMap, ""), 
+			expected: "",
+		},
+		{
+			name:     "TypeSet err fallback",
+			typeInfo: gocql.CollectionType{
+				NativeType: gocql.NewNativeType(0, gocql.TypeSet, ""),
+				Elem: gocql.NewNativeType(0, gocql.TypeSet, ""),
+			},
+			expected: "",
+		},
+		{
+			name:     "TypeList err fallback",
+			typeInfo: gocql.CollectionType{
+				NativeType: gocql.NewNativeType(0, gocql.TypeList, ""),
+				Elem: gocql.NewNativeType(0, gocql.TypeList, ""),
+			},
+			expected: "",
+		},
+		{
+			name:     "TypeMap key err fallback",
+			typeInfo: gocql.CollectionType{
+				NativeType: gocql.NewNativeType(0, gocql.TypeMap, ""),
+				Key: gocql.NewNativeType(0, gocql.TypeMap, ""),
+				Elem: gocql.NewNativeType(0, gocql.TypeInt, ""),
+			},
+			expected: "",
+		},
+		{
+			name:     "TypeMap value err fallback",
+			typeInfo: gocql.CollectionType{
+				NativeType: gocql.NewNativeType(0, gocql.TypeMap, ""),
+				Key: gocql.NewNativeType(0, gocql.TypeInt, ""),
+				Elem: gocql.NewNativeType(0, gocql.TypeMap, ""),
+			},
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual, _ := getTypeString(tt.typeInfo)
+			assert.Equal(t, tt.expected, actual)
+		})
+	}
+}
+
+func TestGetColumns(t *testing.T) {
+	mockKeyspace := &cc.MockKeyspaceMetadata{}
+	pk1Col := &gocql.ColumnMetadata{Name: "pk1", Type: gocql.NewNativeType(0, gocql.TypeInt, "")}
+	ck1Col := &gocql.ColumnMetadata{Name: "ck1", Type: gocql.NewNativeType(0, gocql.TypeVarchar, "")}
+	col1Col := &gocql.ColumnMetadata{Name: "col1", Type: gocql.NewNativeType(0, gocql.TypeBoolean, "")}
+	tables := map[string]*gocql.TableMetadata{
+		"test_table": {
+			Name:              "test_table",
+			PartitionKey:      []*gocql.ColumnMetadata{pk1Col},
+			ClusteringColumns: []*gocql.ColumnMetadata{ck1Col},
+			Columns:           map[string]*gocql.ColumnMetadata{"pk1": pk1Col, "ck1": ck1Col, "col1": col1Col},
+		},
+	}
+	mockKeyspace.On("Tables").Return(tables)
+
+	isi := InfoSchemaImpl{KeyspaceMetadata: mockKeyspace}
+	colDefs, colIds, err := isi.GetColumns(nil, common.SchemaAndName{Name: "test_table"}, nil, nil)
+
+	// Test Case 1: Expect correct columns to be returned
+	assert.NoError(t, err)
+	assert.Len(t, colIds, 3, "Expected three column IDs to be returned")
+	assert.Len(t, colDefs, 3, "Expected three column definitions to be returned")
+
+	// Test Case 2: verify properties of a primary key and a regular column
+	var pkFound, colFound bool
+	for _, id := range colIds {
+		col := colDefs[id]
+		if col.Name == "pk1" {
+			assert.True(t, col.NotNull, "Primary key columns should be NotNull")
+			assert.Equal(t, "int", col.Type.Name)
+			pkFound = true
+		}
+		if col.Name == "col1" {
+			assert.False(t, col.NotNull, "Non-primary key columns should be nullable")
+			assert.Equal(t, "boolean", col.Type.Name)
+			colFound = true
+		}
+	}
+	// Test Case 3: check if columns exist
+	assert.True(t, pkFound, "Primary key 'pk1' was not found in the results")
+	assert.True(t, colFound, "Regular column 'col1' was not found in the results")
+	
+	// Test Case 4: Table doesn't exist in keyspace
+	colDefs, colIds, err = isi.GetColumns(nil, common.SchemaAndName{Name: "test_table1"}, nil, nil)
+	assert.Error(t, err)
+	assert.EqualError(t, err, "table 'test_table1' not found in keyspace metadata")
+	assert.Nil(t, colDefs)
+	assert.Nil(t, colIds)
+
+	// Test Case 5: nil Keyspace
+	isi = InfoSchemaImpl{
+		KeyspaceMetadata: nil,
+	}
+	_, _, err = isi.GetColumns(nil, common.SchemaAndName{Name: "test_table"}, nil, nil)
+	assert.Error(t, err)
+	assert.EqualError(t, err, "keyspace metadata not initialized")
+	
+	// Test Case 6: Error from getTypeString
+	mockKeyspace = &cc.MockKeyspaceMetadata{} 
+	errCol := &gocql.ColumnMetadata{
+		Name: "col1",
+		Type: gocql.NewNativeType(0, gocql.TypeSet, ""), 
+	}
+	tables = map[string]*gocql.TableMetadata{
+		"err_table": {
+			Name:              "err_table",
+			PartitionKey:      []*gocql.ColumnMetadata{},
+			ClusteringColumns: []*gocql.ColumnMetadata{},
+			Columns:           map[string]*gocql.ColumnMetadata{"col1": errCol},
+		},
+	}
+	mockKeyspace.On("Tables").Return(tables).Once()
+
+	isi = InfoSchemaImpl{KeyspaceMetadata: mockKeyspace}
+	colDefs, colIds, err = isi.GetColumns(nil, common.SchemaAndName{Name: "err_table"}, nil, nil)
+	assert.Error(t, err)
+	assert.EqualError(t, err, "invalid set type")
+	assert.Nil(t, colDefs)
+	assert.Nil(t, colIds)
+
+	mockKeyspace.AssertExpectations(t)
+}
+
+func TestGetConstraints(t *testing.T) {
+	mockKeyspace := &cc.MockKeyspaceMetadata{}
+	tables := map[string]*gocql.TableMetadata{
+		"test_table": {
+			Name:              "test_table",
+			PartitionKey:      []*gocql.ColumnMetadata{{Name: "pk1"}, {Name: "pk2"}},
+			ClusteringColumns: []*gocql.ColumnMetadata{{Name: "ck1"}},
+		},
+	}
+	mockKeyspace.On("Tables").Return(tables)
+
+	isi := InfoSchemaImpl{KeyspaceMetadata: mockKeyspace}
+	pks, cks, fks, err := isi.GetConstraints(nil, common.SchemaAndName{Name: "test_table"})
+
+	assert.NoError(t, err)
+	// Test Case 1: verify pk, fk and ck
+	assert.Equal(t, []string{"pk1", "pk2", "ck1"}, pks, "Primary keys did not match expected")
+	assert.Empty(t, cks, "Check constraints should be empty for Cassandra")
+	assert.Empty(t, fks, "Foreign key constraints should be empty for Cassandra")
+	// Test Case 2: Table doesn't exist in keyspace
+	pks, cks, fks, err = isi.GetConstraints(nil, common.SchemaAndName{Name: "test_table1"})
+	assert.Error(t, err)
+	assert.EqualError(t, err, "table 'test_table1' not found in keyspace metadata")
+	assert.Nil(t, pks)
+	assert.Nil(t, cks)
+	assert.Nil(t, fks)
+	// Test Case 3: nil Keyspace
+	isi = InfoSchemaImpl{
+		KeyspaceMetadata: nil,
+	}
+	_, _, _, err = isi.GetConstraints(nil, common.SchemaAndName{Name: "test_table"})
+	assert.Error(t, err)
+	assert.EqualError(t, err, "keyspace metadata not initialized")
+	mockKeyspace.AssertExpectations(t)
+}
+
+func TestGetForeignKeys(t *testing.T) {
+	isi := InfoSchemaImpl{}
+	fks, err := isi.GetForeignKeys(nil, common.SchemaAndName{})
+	// Test Case: should return null
+	assert.NoError(t, err)
+	assert.Nil(t, fks, "GetForeignKeys should always return nil for Cassandra")
+}
+
+func TestGetIndexes(t *testing.T) {
+	mockKeyspace := &cc.MockKeyspaceMetadata{}
+	tables := map[string]*gocql.TableMetadata{
+		"test_table": {
+			Name: "test_table",
+			Columns: map[string]*gocql.ColumnMetadata{
+				"col1": {Name: "col1"},
+				"col2": {Name: "col2", Index: gocql.ColumnIndexMetadata{Name: "col2_idx"}},
+			},
+		},
+	}
+	mockKeyspace.On("Tables").Return(tables)
+
+	isi := InfoSchemaImpl{KeyspaceMetadata: mockKeyspace}
+	colNameIdMap := map[string]string{"col1": "id1", "col2": "id2"}
+	conv := internal.MakeConv()
+	indexes, err := isi.GetIndexes(conv, common.SchemaAndName{Name: "test_table"}, colNameIdMap)
+
+	assert.NoError(t, err)
+	// Test Case 1: Expect exactly one index to be found
+	assert.Len(t, indexes, 1, "Expected exactly one index to be found")
+	idx := indexes[0]
+	// Test Case 2: check name and conditions
+	assert.Equal(t, "col2_idx", idx.Name)
+	assert.False(t, idx.Unique, "Cassandra secondary indexes should be non-unique")
+	assert.Len(t, idx.Keys, 1)
+	assert.Equal(t, "id2", idx.Keys[0].ColId)
+	// Test Case 3: Table doesn't exist in keyspace
+	indexes, err = isi.GetIndexes(conv, common.SchemaAndName{Name: "test_table1"}, colNameIdMap)
+	assert.Error(t, err)
+	assert.EqualError(t, err, "table 'test_table1' not found in keyspace metadata")
+	assert.Nil(t, indexes)
+	// Test Case 4: nil Keyspace
+	isi = InfoSchemaImpl{
+		KeyspaceMetadata: nil,
+	}
+	_, err = isi.GetIndexes(conv, common.SchemaAndName{Name: "test_table"}, colNameIdMap)
+	assert.Error(t, err)
+	assert.EqualError(t, err, "keyspace metadata not initialized")
+	mockKeyspace.AssertExpectations(t)
+}
+
+func TestDataMigrationStubs(t *testing.T) {
+	isi := InfoSchemaImpl{}
+	ctx := context.Background()
+	conv := internal.MakeConv()
+
+	_, err := isi.GetRowsFromTable(conv, "table1")
+	assert.ErrorIs(t, err, errNotSupported)
+
+	_, err = isi.GetRowCount(common.SchemaAndName{Name: "table1"})
+	assert.ErrorIs(t, err, errNotSupported)
+
+	err = isi.ProcessData(conv, "table1", schema.Table{}, nil, ddl.CreateTable{}, internal.AdditionalDataAttributes{})
+	assert.ErrorIs(t, err, errNotSupported)
+
+	_, err = isi.StartChangeDataCapture(ctx, conv)
+	assert.ErrorIs(t, err, errNotSupported)
+
+	_, err = isi.StartStreamingMigration(ctx, "", nil, conv, nil)
+	assert.ErrorIs(t, err, errNotSupported)
+}

--- a/sources/cassandra/toddl.go
+++ b/sources/cassandra/toddl.go
@@ -1,0 +1,357 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package cassandra handles schema migration from Cassandra.
+package cassandra
+
+import (
+	"strings"
+
+	"github.com/GoogleCloudPlatform/spanner-migration-tool/internal"
+	"github.com/GoogleCloudPlatform/spanner-migration-tool/schema"
+	"github.com/GoogleCloudPlatform/spanner-migration-tool/spanner/ddl"
+)
+
+// ToDdlImpl Cassandra specific implementation for the ToDdl.
+type ToDdlImpl struct {
+	typeMapper CassandraMappingProvider
+}
+
+func (tdi ToDdlImpl) ToSpannerType(conv *internal.Conv, spType string, srcType schema.Type, isPk bool) (ddl.Type, []internal.SchemaIssue) {
+	return tdi.typeMapper.GetSpannerType(srcType.Name, spType)
+}
+
+func (tdi ToDdlImpl) GetColumnAutoGen(conv *internal.Conv, autoGenCol ddl.AutoGenCol, colId string, tableId string) (*ddl.AutoGenCol, error) {
+	return &ddl.AutoGenCol{}, nil
+}
+
+func (tdi ToDdlImpl) GetTypeOption(srcTypeName string, spType ddl.Type) string {
+	return tdi.typeMapper.GetOption(srcTypeName, spType)
+}
+
+// TODO: Make CassandraTypeOption an array of strings
+// This might be needed for future work of supporting maps as interleaved tables.
+// CassandraDdlInfo encapsulates info about the ddl type, cassandra_type and issue
+type CassandraDdlInfo struct {
+	SpannerType              ddl.Type
+	CassandraTypeOption      string
+	Issues                   []internal.SchemaIssue
+}
+
+// Static initialisation of base map
+// This maps a Cassandra primitive type to a list of options for Spanner DDL type. 
+// The first option is the default option. 
+// The other options are non-default that a user can select.
+var typeMappings = map[string][]CassandraDdlInfo{
+	"TINYINT": {
+		{
+			SpannerType:         ddl.Type{Name: ddl.Int64},
+			CassandraTypeOption: "tinyint",
+			Issues:              []internal.SchemaIssue{internal.Widened},
+		},
+		{
+			SpannerType:         ddl.Type{Name: ddl.String, Len: ddl.MaxLength},
+			CassandraTypeOption: "text",
+			Issues:              []internal.SchemaIssue{internal.Widened},
+		},
+	},
+	"SMALLINT": {
+		{
+			SpannerType:         ddl.Type{Name: ddl.Int64},
+			CassandraTypeOption: "smallint",
+			Issues:              []internal.SchemaIssue{internal.Widened},
+		},
+		{
+			SpannerType:         ddl.Type{Name: ddl.String, Len: ddl.MaxLength},
+			CassandraTypeOption: "text",
+			Issues:              []internal.SchemaIssue{internal.Widened},
+		},
+	},
+	"INT": {
+		{
+			SpannerType:         ddl.Type{Name: ddl.Int64},
+			CassandraTypeOption: "int",
+			Issues:              []internal.SchemaIssue{internal.Widened},
+		},
+		{
+			SpannerType:         ddl.Type{Name: ddl.String, Len: ddl.MaxLength},
+			CassandraTypeOption: "text",
+			Issues:              []internal.SchemaIssue{internal.Widened},
+		},
+	},
+	"BIGINT": {
+		{
+			SpannerType:         ddl.Type{Name: ddl.Int64},
+			CassandraTypeOption: "bigint",
+			Issues:              nil,
+		},
+		{
+			SpannerType:         ddl.Type{Name: ddl.String, Len: ddl.MaxLength},
+			CassandraTypeOption: "text",
+			Issues:              []internal.SchemaIssue{internal.Widened},
+		},
+	},
+	"FLOAT": {
+		{
+			SpannerType:         ddl.Type{Name: ddl.Float32},
+			CassandraTypeOption: "float",
+			Issues:              nil,
+		},
+		{
+			SpannerType:         ddl.Type{Name: ddl.Float64},
+			CassandraTypeOption: "double",
+			Issues:              []internal.SchemaIssue{internal.Widened},
+		},
+		{
+			SpannerType:         ddl.Type{Name: ddl.String, Len: ddl.MaxLength},
+			CassandraTypeOption: "text",
+			Issues:              []internal.SchemaIssue{internal.Widened},
+		},
+	},
+	"DOUBLE": {
+		{
+			SpannerType:         ddl.Type{Name: ddl.Float64},
+			CassandraTypeOption: "double",
+			Issues:              nil,
+		},
+		{
+			SpannerType:         ddl.Type{Name: ddl.String, Len: ddl.MaxLength},
+			CassandraTypeOption: "text",
+			Issues:              []internal.SchemaIssue{internal.Widened},
+		},
+	},
+	"DECIMAL": {
+		// TODO: Generate appropriate SchemaIssue to warn of potential data loss
+		{
+			SpannerType:         ddl.Type{Name: ddl.Numeric},
+			CassandraTypeOption: "decimal",
+			Issues:              nil,
+		},
+	},
+	"VARINT": {
+		// TODO: Generate appropriate SchemaIssue to warn of potential data loss
+		{
+			SpannerType:         ddl.Type{Name: ddl.Numeric},
+			CassandraTypeOption: "varint",
+			Issues:              nil,
+		},
+		{
+			SpannerType:         ddl.Type{Name: ddl.String, Len: ddl.MaxLength},
+			CassandraTypeOption: "text",
+			Issues:              []internal.SchemaIssue{internal.Widened},
+		},
+		{
+			SpannerType:         ddl.Type{Name: ddl.Bytes, Len: ddl.MaxLength},
+			CassandraTypeOption: "blob",
+			Issues:              []internal.SchemaIssue{internal.Widened},
+		},
+	},
+	"TEXT": {
+		{
+			SpannerType:         ddl.Type{Name: ddl.String, Len: ddl.MaxLength},
+			CassandraTypeOption: "text",
+			Issues:              nil,
+		},
+		{
+			SpannerType:         ddl.Type{Name: ddl.Bytes, Len: ddl.MaxLength},
+			CassandraTypeOption: "blob",
+			Issues:              []internal.SchemaIssue{internal.Widened},
+		},
+	},
+	"VARCHAR": {
+		{
+			SpannerType:         ddl.Type{Name: ddl.String, Len: ddl.MaxLength},
+			CassandraTypeOption: "varchar",
+			Issues:              nil,
+		},
+		{
+			SpannerType:         ddl.Type{Name: ddl.Bytes, Len: ddl.MaxLength},
+			CassandraTypeOption: "blob",
+			Issues:              []internal.SchemaIssue{internal.Widened},
+		},
+	},
+	"ASCII": {
+		{
+			SpannerType:         ddl.Type{Name: ddl.String, Len: ddl.MaxLength},
+			CassandraTypeOption: "ascii",
+			Issues:              nil,
+		},
+		{
+			SpannerType:         ddl.Type{Name: ddl.Bytes, Len: ddl.MaxLength},
+			CassandraTypeOption: "blob",
+			Issues:              []internal.SchemaIssue{internal.Widened},
+		},
+	},
+	// TODO: Generate appropriate SchemaIssue to warn 
+	// that the field might acceept UUID of unsupported versions as compared to Cassandra.
+	"UUID": {
+		{
+			SpannerType:         ddl.Type{Name: ddl.String, Len: ddl.MaxLength},
+			CassandraTypeOption: "uuid",
+			Issues:              nil,
+		},
+		{
+			SpannerType:         ddl.Type{Name: ddl.Bytes, Len: 16},
+			CassandraTypeOption: "uuid",
+			Issues:              []internal.SchemaIssue{internal.Widened},
+		},
+	},
+	// TODO: Generate appropriate SchemaIssue to warn 
+	// that the field might acceept TIMEUUID of unsupported versions as compared to Cassandra.
+	"TIMEUUID": {
+		{
+			SpannerType:         ddl.Type{Name: ddl.String, Len: ddl.MaxLength},
+			CassandraTypeOption: "timeuuid",
+			Issues:              nil,
+		},
+		{
+			SpannerType:         ddl.Type{Name: ddl.Bytes, Len: 16},
+			CassandraTypeOption: "timeuuid",
+			Issues:              []internal.SchemaIssue{internal.Widened},
+		},
+	},
+	"INET": {
+		{
+			SpannerType:         ddl.Type{Name: ddl.String, Len: ddl.MaxLength},
+			CassandraTypeOption: "inet",
+			Issues:              nil,
+		},
+	},
+	"BLOB": {
+		{
+			SpannerType:         ddl.Type{Name: ddl.Bytes, Len: ddl.MaxLength},
+			CassandraTypeOption: "blob",
+			Issues:              nil,
+		},
+		{
+			SpannerType:         ddl.Type{Name: ddl.String, Len: ddl.MaxLength},
+			CassandraTypeOption: "text",
+			Issues:              []internal.SchemaIssue{internal.Widened},
+		},
+	},
+	"DATE": {
+		{
+			SpannerType:         ddl.Type{Name: ddl.Date},
+			CassandraTypeOption: "date",
+			Issues:              nil,
+		},
+		{
+			SpannerType:         ddl.Type{Name: ddl.String, Len: ddl.MaxLength},
+			CassandraTypeOption: "text",
+			Issues:              []internal.SchemaIssue{internal.Widened},
+		},
+	},
+	"TIMESTAMP": {
+		{
+			SpannerType:         ddl.Type{Name: ddl.Timestamp},
+			CassandraTypeOption: "timestamp",
+			Issues:              nil,
+		},
+		{
+			SpannerType:         ddl.Type{Name: ddl.String, Len: ddl.MaxLength},
+			CassandraTypeOption: "text",
+			Issues:              []internal.SchemaIssue{internal.Widened},
+		},
+	},
+	"TIME": {
+		{
+			SpannerType:         ddl.Type{Name: ddl.Int64},
+			CassandraTypeOption: "time",
+			Issues:              []internal.SchemaIssue{internal.Time},
+		},
+		{
+			SpannerType:         ddl.Type{Name: ddl.String, Len: ddl.MaxLength},
+			CassandraTypeOption: "text",
+			Issues:              []internal.SchemaIssue{internal.Widened},
+		},
+	},
+	"DURATION": {
+		// TODO: Generate appropriate SchemaIssue to warn about adapter not supporting duration
+		{
+			SpannerType:         ddl.Type{Name: ddl.String, Len: ddl.MaxLength},
+			CassandraTypeOption: "duration",
+			Issues:              nil,
+		},
+	},
+	"BOOLEAN": {
+		{
+			SpannerType:         ddl.Type{Name: ddl.Bool},
+			CassandraTypeOption: "boolean",
+			Issues:              nil,
+		},
+		{
+			SpannerType:         ddl.Type{Name: ddl.Int64},
+			CassandraTypeOption: "int",
+			Issues:              []internal.SchemaIssue{internal.Widened},
+		},
+		{
+			SpannerType:         ddl.Type{Name: ddl.String, Len: ddl.MaxLength},
+			CassandraTypeOption: "text",
+			Issues:              []internal.SchemaIssue{internal.Widened},
+		},
+	},
+	"COUNTER": {
+		// TODO: Generate appropriate SchemaIssue to warn about adapter not supporting counter
+		{
+			SpannerType:         ddl.Type{Name: ddl.Int64},
+			CassandraTypeOption: "counter",
+			Issues:              nil,
+		},
+	},
+}
+
+// CassandraMappingProvider defines an interface for type mapping.
+type CassandraMappingProvider interface {
+	GetSpannerType(cassandraTypeName string, spType string) (ddl.Type, []internal.SchemaIssue)
+	GetOption(cassandraTypeName string, spType ddl.Type) string
+}
+
+// CassandraTypeMapper implements CassandraMappingProvider.
+type CassandraTypeMapper struct{}
+
+func NewCassandraTypeMapper() *CassandraTypeMapper {
+	return &CassandraTypeMapper{}
+}
+
+// getMapping retrieves a Spanner DDL mapping rule for a given Cassandra type and Spanner Type(if non-default).
+func (m *CassandraTypeMapper) getMapping(cassandraTypeName string, spTypeName string) (CassandraDdlInfo, bool) {
+	s := strings.ToUpper(strings.ReplaceAll(cassandraTypeName, " ", ""))
+	if mappings, ok := typeMappings[s]; ok && len(mappings) > 0 {
+		if spTypeName != "" {
+			for _, mapping := range mappings {
+				if mapping.SpannerType.Name == spTypeName {
+					return mapping, true
+				}
+			}
+		}
+		return mappings[0], true
+	}
+	return CassandraDdlInfo{}, false
+}
+
+// GetSpannerType finds the correct mapping for the Spanner type and issues
+func (m *CassandraTypeMapper) GetSpannerType(cassandraTypeName string, spType string) (ddl.Type, []internal.SchemaIssue) {
+	if mapping, ok := m.getMapping(cassandraTypeName, spType); ok {
+		return mapping.SpannerType, mapping.Issues
+	}
+	return ddl.Type{Name: ddl.String, Len: ddl.MaxLength}, []internal.SchemaIssue{internal.NoGoodType}
+}
+
+// GetOption finds the correct CassandraTypeOption string for a given mapping
+func (m *CassandraTypeMapper) GetOption(cassandraTypeName string, spType ddl.Type) string {
+	if mapping, ok := m.getMapping(cassandraTypeName, spType.Name); ok {
+		return mapping.CassandraTypeOption
+	}
+	return cassandraTypeName
+}

--- a/sources/cassandra/toddl_test.go
+++ b/sources/cassandra/toddl_test.go
@@ -1,0 +1,422 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package cassandra handles schema migration from Cassandra.
+package cassandra
+
+import (
+	"testing"
+
+	"github.com/GoogleCloudPlatform/spanner-migration-tool/internal"
+	"github.com/GoogleCloudPlatform/spanner-migration-tool/schema"
+	"github.com/GoogleCloudPlatform/spanner-migration-tool/spanner/ddl"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+type MockCassandraMappingProvider struct {
+	mock.Mock
+}
+
+func (m *MockCassandraMappingProvider) GetSpannerType(cassandraTypeName string, spType string) (ddl.Type, []internal.SchemaIssue) {
+	args := m.Called(cassandraTypeName, spType)
+	return args.Get(0).(ddl.Type), args.Get(1).([]internal.SchemaIssue)
+}
+
+func (m *MockCassandraMappingProvider) GetOption(cassandraTypeName string, spType ddl.Type) string {
+	args := m.Called(cassandraTypeName, spType)
+	return args.String(0)
+}
+
+func TestToSpannerType(t *testing.T) {
+
+	mockMapper := new(MockCassandraMappingProvider)
+	srcTypeName := "text"
+	expectedSpannerType := ddl.Type{Name: ddl.String, Len: ddl.MaxLength}
+	expectedIssues := []internal.SchemaIssue{internal.NoGoodType}
+	mockMapper.On("GetSpannerType", srcTypeName, "").Return(expectedSpannerType, expectedIssues)
+	tdi := &ToDdlImpl{
+		typeMapper: mockMapper,
+	}
+	spType, issues := tdi.ToSpannerType(nil, "", schema.Type{Name: srcTypeName}, false)
+	mockMapper.AssertCalled(t, "GetSpannerType", srcTypeName, "")
+	assert.Equal(t, expectedSpannerType, spType)
+	assert.Equal(t, expectedIssues, issues)
+}
+
+func TestGetColumnAutoGen(t *testing.T) {
+	tdi := &ToDdlImpl{}
+	autoGenCol, err := tdi.GetColumnAutoGen(nil, ddl.AutoGenCol{}, "", "")
+	assert.Nil(t, err)
+	assert.Equal(t, &ddl.AutoGenCol{}, autoGenCol)
+}
+
+func TestGetTypeOption(t *testing.T) {
+	mockMapper := new(MockCassandraMappingProvider)
+	srcTypeName := "tinyint"
+	spannerType := ddl.Type{Name: ddl.String, Len: ddl.MaxLength}
+	expectedOption := "text"
+	mockMapper.On("GetOption", srcTypeName, spannerType).Return(expectedOption)
+	tdi := &ToDdlImpl{
+		typeMapper: mockMapper,
+	}
+	option := tdi.GetTypeOption(srcTypeName, spannerType)
+	mockMapper.AssertCalled(t, "GetOption", srcTypeName, spannerType)
+	assert.Equal(t, expectedOption, option)
+}
+
+func TestCassandraTypeMapper(t *testing.T) {
+	mapper := NewCassandraTypeMapper()
+
+	testCases := []struct {
+		name                string
+		cassandraType       string
+		userSpannerType     string
+		expectedSpannerType ddl.Type
+		expectedOption      string
+		expectedIssues      []internal.SchemaIssue
+	}{
+		{
+			name:                "Default tinyint",
+			cassandraType:       "tinyint",
+			expectedSpannerType: ddl.Type{Name: ddl.Int64},
+			expectedOption:      "tinyint",
+			expectedIssues:      []internal.SchemaIssue{internal.Widened},
+		},
+		{
+			name:                "Override tinyint to STRING",
+			cassandraType:       "tinyint",
+			userSpannerType:     ddl.String,
+			expectedSpannerType: ddl.Type{Name: ddl.String, Len: ddl.MaxLength},
+			expectedOption:      "text",
+			expectedIssues:      []internal.SchemaIssue{internal.Widened},
+		},
+		{
+			name:                "Default smallint",
+			cassandraType:       "smallint",
+			expectedSpannerType: ddl.Type{Name: ddl.Int64},
+			expectedOption:      "smallint",
+			expectedIssues:      []internal.SchemaIssue{internal.Widened},
+		},
+		{
+			name:                "Override smallint to STRING",
+			cassandraType:       "smallint",
+			userSpannerType:     ddl.String,
+			expectedSpannerType: ddl.Type{Name: ddl.String, Len: ddl.MaxLength},
+			expectedOption:      "text",
+			expectedIssues:      []internal.SchemaIssue{internal.Widened},
+		},
+		{
+			name:                "Default int",
+			cassandraType:       "int",
+			expectedSpannerType: ddl.Type{Name: ddl.Int64},
+			expectedOption:      "int",
+			expectedIssues:      []internal.SchemaIssue{internal.Widened},
+		},
+		{
+			name:                "Override int to STRING",
+			cassandraType:       "int",
+			userSpannerType:     ddl.String,
+			expectedSpannerType: ddl.Type{Name: ddl.String, Len: ddl.MaxLength},
+			expectedOption:      "text",
+			expectedIssues:      []internal.SchemaIssue{internal.Widened},
+		},
+		{
+			name:                "Default bigint",
+			cassandraType:       "bigint",
+			expectedSpannerType: ddl.Type{Name: ddl.Int64},
+			expectedOption:      "bigint",
+		},
+		{
+			name:                "Override bigint to STRING",
+			cassandraType:       "bigint",
+			userSpannerType:     ddl.String,
+			expectedSpannerType: ddl.Type{Name: ddl.String, Len: ddl.MaxLength},
+			expectedOption:      "text",
+			expectedIssues:      []internal.SchemaIssue{internal.Widened},
+		},
+		{
+			name:                "Default float",
+			cassandraType:       "float",
+			expectedSpannerType: ddl.Type{Name: ddl.Float32},
+			expectedOption:      "float",
+		},
+		{
+			name:                "Override float to FLOAT64",
+			cassandraType:       "float",
+			userSpannerType:     ddl.Float64,
+			expectedSpannerType: ddl.Type{Name: ddl.Float64},
+			expectedOption:      "double",
+			expectedIssues:      []internal.SchemaIssue{internal.Widened},
+		},
+		{
+			name:                "Override float to STRING",
+			cassandraType:       "float",
+			userSpannerType:     ddl.String,
+			expectedSpannerType: ddl.Type{Name: ddl.String, Len: ddl.MaxLength},
+			expectedOption:      "text",
+			expectedIssues:      []internal.SchemaIssue{internal.Widened},
+		},
+		{
+			name:                "Default double",
+			cassandraType:       "double",
+			expectedSpannerType: ddl.Type{Name: ddl.Float64},
+			expectedOption:      "double",
+		},
+		{
+			name:                "Override double to STRING",
+			cassandraType:       "double",
+			userSpannerType:     ddl.String,
+			expectedSpannerType: ddl.Type{Name: ddl.String, Len: ddl.MaxLength},
+			expectedOption:      "text",
+			expectedIssues:      []internal.SchemaIssue{internal.Widened},
+		},
+		{
+			name:                "Default decimal",
+			cassandraType:       "decimal",
+			expectedSpannerType: ddl.Type{Name: ddl.Numeric},
+			expectedOption:      "decimal",
+		},
+		{
+			name:                "Default varint",
+			cassandraType:       "varint",
+			expectedSpannerType: ddl.Type{Name: ddl.Numeric},
+			expectedOption:      "varint",
+		},
+		{
+			name:                "Override varint to STRING",
+			cassandraType:       "varint",
+			userSpannerType:     ddl.String,
+			expectedSpannerType: ddl.Type{Name: ddl.String, Len: ddl.MaxLength},
+			expectedOption:      "text",
+			expectedIssues:      []internal.SchemaIssue{internal.Widened},
+		},
+		{
+			name:                "Override varint to BYTES",
+			cassandraType:       "varint",
+			userSpannerType:     ddl.Bytes,
+			expectedSpannerType: ddl.Type{Name: ddl.Bytes, Len: ddl.MaxLength},
+			expectedOption:      "blob",
+			expectedIssues:      []internal.SchemaIssue{internal.Widened},
+		},
+		{
+			name:                "Default text",
+			cassandraType:       "text",
+			expectedSpannerType: ddl.Type{Name: ddl.String, Len: ddl.MaxLength},
+			expectedOption:      "text",
+		},
+		{
+			name:                "Override text to BYTES",
+			cassandraType:       "text",
+			userSpannerType:     ddl.Bytes,
+			expectedSpannerType: ddl.Type{Name: ddl.Bytes, Len: ddl.MaxLength},
+			expectedOption:      "blob",
+			expectedIssues:      []internal.SchemaIssue{internal.Widened},
+		},
+		{
+			name:                "Default varchar",
+			cassandraType:       "varchar",
+			expectedSpannerType: ddl.Type{Name: ddl.String, Len: ddl.MaxLength},
+			expectedOption:      "varchar",
+		},
+		{
+			name:                "Override varchar to BYTES",
+			cassandraType:       "varchar",
+			userSpannerType:     ddl.Bytes,
+			expectedSpannerType: ddl.Type{Name: ddl.Bytes, Len: ddl.MaxLength},
+			expectedOption:      "blob",
+			expectedIssues:      []internal.SchemaIssue{internal.Widened},
+		},
+		{
+			name:                "Default ascii",
+			cassandraType:       "ascii",
+			expectedSpannerType: ddl.Type{Name: ddl.String, Len: ddl.MaxLength},
+			expectedOption:      "ascii",
+		},
+		{
+			name:                "Override ascii to BYTES",
+			cassandraType:       "ascii",
+			userSpannerType:     ddl.Bytes,
+			expectedSpannerType: ddl.Type{Name: ddl.Bytes, Len: ddl.MaxLength},
+			expectedOption:      "blob",
+			expectedIssues:      []internal.SchemaIssue{internal.Widened},
+		},
+		{
+			name:                "Default uuid",
+			cassandraType:       "uuid",
+			expectedSpannerType: ddl.Type{Name: ddl.String, Len: ddl.MaxLength},
+			expectedOption:      "uuid",
+		},
+		{
+			name:                "Override uuid to BYTES",
+			cassandraType:       "uuid",
+			userSpannerType:     ddl.Bytes,
+			expectedSpannerType: ddl.Type{Name: ddl.Bytes, Len: 16},
+			expectedOption:      "uuid",
+			expectedIssues:      []internal.SchemaIssue{internal.Widened},
+		},
+		{
+			name:                "Default timeuuid",
+			cassandraType:       "timeuuid",
+			expectedSpannerType: ddl.Type{Name: ddl.String, Len: ddl.MaxLength},
+			expectedOption:      "timeuuid",
+		},
+		{
+			name:                "Override timeuuid to BYTES",
+			cassandraType:       "timeuuid",
+			userSpannerType:     ddl.Bytes,
+			expectedSpannerType: ddl.Type{Name: ddl.Bytes, Len: 16},
+			expectedOption:      "timeuuid",
+			expectedIssues:      []internal.SchemaIssue{internal.Widened},
+		},
+		{
+			name:                "Default inet",
+			cassandraType:       "inet",
+			expectedSpannerType: ddl.Type{Name: ddl.String, Len: ddl.MaxLength},
+			expectedOption:      "inet",
+		},
+		{
+			name:                "Default blob",
+			cassandraType:       "blob",
+			expectedSpannerType: ddl.Type{Name: ddl.Bytes, Len: ddl.MaxLength},
+			expectedOption:      "blob",
+		},
+		{
+			name:                "Override blob to STRING",
+			cassandraType:       "blob",
+			userSpannerType:     ddl.String,
+			expectedSpannerType: ddl.Type{Name: ddl.String, Len: ddl.MaxLength},
+			expectedOption:      "text",
+			expectedIssues:      []internal.SchemaIssue{internal.Widened},
+		},
+		{
+			name:                "Default date",
+			cassandraType:       "date",
+			expectedSpannerType: ddl.Type{Name: ddl.Date},
+			expectedOption:      "date",
+		},
+		{
+			name:                "Override date to STRING",
+			cassandraType:       "date",
+			userSpannerType:     ddl.String,
+			expectedSpannerType: ddl.Type{Name: ddl.String, Len: ddl.MaxLength},
+			expectedOption:      "text",
+			expectedIssues:      []internal.SchemaIssue{internal.Widened},
+		},
+		{
+			name:                "Default timestamp",
+			cassandraType:       "timestamp",
+			expectedSpannerType: ddl.Type{Name: ddl.Timestamp},
+			expectedOption:      "timestamp",
+		},
+		{
+			name:                "Override timestamp to STRING",
+			cassandraType:       "timestamp",
+			userSpannerType:     ddl.String,
+			expectedSpannerType: ddl.Type{Name: ddl.String, Len: ddl.MaxLength},
+			expectedOption:      "text",
+			expectedIssues:      []internal.SchemaIssue{internal.Widened},
+		},
+		{
+			name:                "Default time",
+			cassandraType:       "time",
+			expectedSpannerType: ddl.Type{Name: ddl.Int64},
+			expectedOption:      "time",
+			expectedIssues:      []internal.SchemaIssue{internal.Time},
+		},
+		{
+			name:                "Override time to STRING",
+			cassandraType:       "time",
+			userSpannerType:     ddl.String,
+			expectedSpannerType: ddl.Type{Name: ddl.String, Len: ddl.MaxLength},
+			expectedOption:      "text",
+			expectedIssues:      []internal.SchemaIssue{internal.Widened},
+		},
+		{
+			name:                "Default duration",
+			cassandraType:       "duration",
+			expectedSpannerType: ddl.Type{Name: ddl.String, Len: ddl.MaxLength},
+			expectedOption:      "duration",
+		},
+		{
+			name:                "Default boolean",
+			cassandraType:       "boolean",
+			expectedSpannerType: ddl.Type{Name: ddl.Bool},
+			expectedOption:      "boolean",
+		},
+		{
+			name:                "Override boolean to INT64",
+			cassandraType:       "boolean",
+			userSpannerType:     ddl.Int64,
+			expectedSpannerType: ddl.Type{Name: ddl.Int64},
+			expectedOption:      "int",
+			expectedIssues:      []internal.SchemaIssue{internal.Widened},
+		},
+		{
+			name:                "Override boolean to STRING",
+			cassandraType:       "boolean",
+			userSpannerType:     ddl.String,
+			expectedSpannerType: ddl.Type{Name: ddl.String, Len: ddl.MaxLength},
+			expectedOption:      "text",
+			expectedIssues:      []internal.SchemaIssue{internal.Widened},
+		},
+		{
+			name:                "Default counter",
+			cassandraType:       "counter",
+			expectedSpannerType: ddl.Type{Name: ddl.Int64},
+			expectedOption:      "counter",
+		},
+		{
+			name:                "Fallback list",
+			cassandraType:       "list<text>",
+			expectedSpannerType: ddl.Type{Name: ddl.String, Len: ddl.MaxLength},
+			expectedOption:      "list<text>",
+			expectedIssues:      []internal.SchemaIssue{internal.NoGoodType},
+		},
+		{
+			name:                "Fallback set",
+			cassandraType:       "set<text>",
+			expectedSpannerType: ddl.Type{Name: ddl.String, Len: ddl.MaxLength},
+			expectedOption:      "set<text>",
+			expectedIssues:      []internal.SchemaIssue{internal.NoGoodType},
+		},
+		{
+			name:                "Fallback map",
+			cassandraType:       "map<text,int>",
+			expectedSpannerType: ddl.Type{Name: ddl.String, Len: ddl.MaxLength},
+			expectedOption:      "map<text,int>",
+			expectedIssues:      []internal.SchemaIssue{internal.NoGoodType},
+		},
+		{
+			name:                "Fallback unknown type",
+			cassandraType:       "some_udt",
+			expectedSpannerType: ddl.Type{Name: ddl.String, Len: ddl.MaxLength},
+			expectedOption:      "some_udt",
+			expectedIssues:      []internal.SchemaIssue{internal.NoGoodType},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Test GetSpannerType
+			spType, issues := mapper.GetSpannerType(tc.cassandraType, tc.userSpannerType)
+			assert.Equal(t, tc.expectedSpannerType, spType)
+			assert.ElementsMatch(t, tc.expectedIssues, issues)
+
+			// Test GetOption
+			option := mapper.GetOption(tc.cassandraType, spType)
+			assert.Equal(t, tc.expectedOption, option)
+		})
+	}
+}

--- a/sources/common/mocks.go
+++ b/sources/common/mocks.go
@@ -126,3 +126,25 @@ func (m *MockToDdl) GetColumnAutoGen(conv *internal.Conv, autoGenCol ddl.AutoGen
 	}
 	return args.Get(0).(*ddl.AutoGenCol), args.Error(1)
 }
+
+// MockOptionProvider is a mock implementation of OptionProvider
+type MockOptionProvider struct {
+	mock.Mock
+}
+
+// ToSpannerType and GetCOlumnAutoGen are methods of the ToDdl interface
+func (m *MockOptionProvider) ToSpannerType(conv *internal.Conv, spType string, srcType schema.Type, isPk bool) (ddl.Type, []internal.SchemaIssue) {
+	args := m.Called(conv, spType, srcType, isPk)
+	return args.Get(0).(ddl.Type), args.Get(1).([]internal.SchemaIssue)
+}
+
+func (m *MockOptionProvider) GetColumnAutoGen(conv *internal.Conv, autoGenCol ddl.AutoGenCol, colId string, tableId string) (*ddl.AutoGenCol, error) {
+	args := m.Called(conv, autoGenCol, colId, tableId)
+	return args.Get(0).(*ddl.AutoGenCol), args.Error(1)
+}
+
+// GetTypeOption is a method of the OptionProvider interface
+func (m *MockOptionProvider) GetTypeOption(srcTypeName string, spType ddl.Type) string {
+	args := m.Called(srcTypeName, spType)
+	return args.String(0)
+}

--- a/sources/common/toddl.go
+++ b/sources/common/toddl.go
@@ -53,6 +53,12 @@ type ToDdl interface {
 	GetColumnAutoGen(conv *internal.Conv, autoGenCol ddl.AutoGenCol, colId string, tableId string) (*ddl.AutoGenCol, error)
 }
 
+// CassandraOptionProvider is an interface that can be implemented by ToDdl
+// implementations for sources that provide specific type options, like Cassandra.
+type OptionProvider interface {
+	GetTypeOption(srcTypeName string, spType ddl.Type) string
+}
+
 type SchemaToSpannerInterface interface {
 	SchemaToSpannerDDL(conv *internal.Conv, toddl ToDdl, attributes internal.AdditionalSchemaAttributes) error
 	SchemaToSpannerDDLHelper(conv *internal.Conv, toddl ToDdl, srcTable schema.Table, isRestore bool) error
@@ -389,7 +395,6 @@ func (ss *SchemaToSpannerImpl) SchemaToSpannerDDLHelper(conv *internal.Conv, tod
 		if len(issues) > 0 {
 			columnLevelIssues[srcColId] = issues
 		}
-
 		spColDef[srcColId] = ddl.ColumnDef{
 			Name:    colName,
 			T:       ty,
@@ -397,6 +402,18 @@ func (ss *SchemaToSpannerImpl) SchemaToSpannerDDLHelper(conv *internal.Conv, tod
 			Comment: "From: " + quoteIfNeeded(srcCol.Name) + " " + srcCol.Type.Print(),
 			Id:      srcColId,
 			AutoGen: *autoGenCol,
+		}
+		// Initialise Opts only for Cassandra source
+		if conv.Source == constants.CASSANDRA {
+			colDef := spColDef[srcColId]
+			if optionProvider, ok := toddl.(OptionProvider); ok {
+				option := optionProvider.GetTypeOption(srcCol.Type.Name, ty)
+				if colDef.Opts == nil {
+					colDef.Opts = make(map[string]string)
+				}
+				colDef.Opts["cassandra_type"] = option
+			}
+			spColDef[srcColId] = colDef
 		}
 		if !checkIfColumnIsPartOfPK(srcColId, srcTable.PrimaryKeys) {
 			totalNonKeyColumnSize += getColumnSize(ty.Name, ty.Len)

--- a/spanner/ddl/ast.go
+++ b/spanner/ddl/ast.go
@@ -187,6 +187,7 @@ type ColumnDef struct {
 	Id           string
 	AutoGen      AutoGenCol
 	DefaultValue DefaultValue
+	Opts         map[string]string
 }
 
 // Config controls how AST nodes are printed (aka unparsed).
@@ -251,6 +252,15 @@ func (cd ColumnDef) PrintColumnDef(c Config) (string, string) {
 		}
 		s += cd.DefaultValue.PrintDefaultValue(cd.T)
 		s += cd.AutoGen.PrintAutoGenCol()
+	}
+	var  opts []string
+	if cd.Opts != nil {
+		if opt, ok := cd.Opts["cassandra_type"]; ok && opt != "" {
+			opts = append(opts, fmt.Sprintf("cassandra_type = '%s'", opt))
+		}
+	}	
+	if len(opts) > 0 {
+		s += " OPTIONS (" + strings.Join(opts, ", ") + ")"
 	}
 	return s, cd.Comment
 }

--- a/spanner/ddl/ast_test.go
+++ b/spanner/ddl/ast_test.go
@@ -90,6 +90,14 @@ func TestPrintColumnDef(t *testing.T) {
 			},
 			expected: "col1 INT64 DEFAULT ((`col2` + 1))",
 		},
+		{
+			in: ColumnDef{
+				Name: "col1",
+				T:    Type{Name: Int64},
+				Opts: map[string]string{"cassandra_type": "bigint"},
+			},
+			expected: "col1 INT64 OPTIONS (cassandra_type = 'bigint')",
+		},
 	}
 	for _, tc := range tests {
 		s, _ := tc.in.PrintColumnDef(Config{ProtectIds: tc.protectIds})


### PR DESCRIPTION
### Overview
This PR extends the Spanner Migration Tool (SMT) to include Cassandra as a supported source for **schema-only migration**  via the **Command-Line Interface (CLI)**. This new capability allows users to connect directly to a Cassandra cluster, discover the schema of a specified keyspace, generate the corresponding Spanner DDL and  and then apply that schema to a target Spanner instance.

A key feature is the generation of `OPTIONS (cassandra_type = '...')` in the Spanner DDL to preserve original type information, ensuring compatibility with the Cassandra Adapter for Spanner.

### Gist
Gist of how the type conversion works is that it uses a statically initialized map that associates Cassandra data type names with their corresponding `Spanner DDL types`, `schema issues`, and the correct `cassandra_type` option string for each valid mapping. This approach was chosen over a large switch statement for better readability, maintainability, and ease of testing. When a source column is processed, this map is used to look up the appropriate conversion rule.

**Note**: This design is highly extensible. To support a new Cassandra primitive type in the future, a developer only needs to add a new entry to the static typeMappings map. Similarly, to support alternative Spanner mappings for an existing Cassandra type, a new TypeMapping struct can be added to the existing slice for that type.

This design also simplifies future support for collections, as the logic can parse a type like list<...> and recursively use this same map to resolve the inner cassandra type.
### Example
**Command**
```
./spanner-migration-tool schema -source=cassandra \
-source-profile="host=<HOST>,port=9042,keyspace=<KEYSPACE>,datacenter=<DATACENTER>,user=<USER>,pwd=<PASSWORD>" \
-target-profile="project=<GCP_PROJECT_ID>,instance=<SPANNER_INSTANCE_ID>"
``` 
**Cassandra DDL**
```
CREATE TABLE IF NOT EXISTS testdb.example_table (
    id UUID PRIMARY KEY,
    ascii_value ASCII,
    bigint_value BIGINT,
    blob_value BLOB,
    boolean_value BOOLEAN,
    decimal_value DECIMAL,
    double_value DOUBLE,
    float_value FLOAT,
    inet_value INET,
    int_value INT,
    smallint_value SMALLINT,
    text_value TEXT,
    timestamp_value TIMESTAMP,
    timeuuid_value TIMEUUID,
    tinyint_value TINYINT,
    varchar_value VARCHAR,
    varint_value VARINT,
    list_value LIST<TINYINT>,
    map_value MAP<TEXT, INT>,
    set_value SET<UUID>,
    date_value DATE,
    time_value TIME
);

CREATE TABLE IF NOT EXISTS sensor_data (
    sensor_id UUID,
    reading_time TIMESTAMP,
    location TEXT,
    temperature DECIMAL,
    humidity DECIMAL,
    pressure DECIMAL,
    PRIMARY KEY ((sensor_id, location), reading_time)
);
``` 
**Spanner DDL in output `cassandra.ddl.txt` file**
```
CREATE TABLE `example_table` (
	`boolean_value` BOOL OPTIONS (cassandra_type = 'boolean'),
	`inet_value` STRING(MAX) OPTIONS (cassandra_type = 'inet'),
	`list_value` ARRAY<INT64> OPTIONS (cassandra_type = 'list<tinyint>'),
	`ascii_value` STRING(MAX) OPTIONS (cassandra_type = 'ascii'),
	`blob_value` BYTES(MAX) OPTIONS (cassandra_type = 'blob'),
	`float_value` FLOAT32 OPTIONS (cassandra_type = 'float'),
	`smallint_value` INT64 OPTIONS (cassandra_type = 'smallint'),
	`text_value` STRING(MAX) OPTIONS (cassandra_type = 'text'),
	`time_value` INT64 OPTIONS (cassandra_type = 'time'),
	`timestamp_value` TIMESTAMP OPTIONS (cassandra_type = 'timestamp'),
	`timeuuid_value` STRING(MAX) OPTIONS (cassandra_type = 'timeuuid'),
	`id` STRING(MAX) NOT NULL  OPTIONS (cassandra_type = 'uuid'),
	`map_value` JSON OPTIONS (cassandra_type = 'map<text,int>'),
	`date_value` DATE OPTIONS (cassandra_type = 'date'),
	`decimal_value` NUMERIC OPTIONS (cassandra_type = 'decimal'),
	`double_value` FLOAT64 OPTIONS (cassandra_type = 'double'),
	`int_value` INT64 OPTIONS (cassandra_type = 'int'),
	`set_value` ARRAY<STRING(MAX)> OPTIONS (cassandra_type = 'set<uuid>'),
	`tinyint_value` INT64 OPTIONS (cassandra_type = 'tinyint'),
	`varchar_value` STRING(MAX) OPTIONS (cassandra_type = 'text'),
	`varint_value` NUMERIC OPTIONS (cassandra_type = 'varint'),
	`bigint_value` INT64 OPTIONS (cassandra_type = 'bigint'),
) PRIMARY KEY (`id`);

CREATE TABLE `sensor_data` (
	`humidity` NUMERIC OPTIONS (cassandra_type = 'decimal'),
	`location` STRING(MAX) NOT NULL  OPTIONS (cassandra_type = 'text'),
	`pressure` NUMERIC OPTIONS (cassandra_type = 'decimal'),
	`reading_time` TIMESTAMP NOT NULL  OPTIONS (cassandra_type = 'timestamp'),
	`sensor_id` STRING(MAX) NOT NULL  OPTIONS (cassandra_type = 'uuid'),
	`temperature` NUMERIC OPTIONS (cassandra_type = 'decimal'),
) PRIMARY KEY (`sensor_id`, `location`, `reading_time`)

```
### Upcoming Changes
1. Support for collection types(List, Set and Map) via CLI
2. Return an error for unsupported types of Cassandra instead of mapping to String [**TODO**]
3. UI Support for Cassandra as source