### PR TITLE
Bug fixes in UI support of Cassandra Schema Migration

### DIFF
--- a/ui/src/app/app.constants.ts
+++ b/ui/src/app/app.constants.ts
@@ -150,7 +150,7 @@ export const ColLength = {
   StorageMaxLength: 9223372036854775807,
   StringMaxLength: 2621440,
   ByteMaxLength: 10485760,
-  DataTypes: ['STRING','BYTES','VARCHAR']
+  DataTypes: ['STRING','BYTES','VARCHAR', 'ARRAY<STRING>', 'ARRAY<BYTES>', 'ARRAY<VARCHAR>']
 }
 
 export const DataTypes = {

--- a/ui/src/app/components/load-session/load-session.component.ts
+++ b/ui/src/app/components/load-session/load-session.component.ts
@@ -29,6 +29,7 @@ export class LoadSessionComponent implements OnInit {
     { value: 'sqlserver', displayName: 'SQL Server' },
     { value: 'oracle', displayName: 'Oracle' },
     { value: 'postgres', displayName: 'PostgreSQL' },
+    { value: 'cassandra', displayName: 'Cassandra' },
   ]
   fileToUpload: File | null = null
   uploadStart: boolean = false

--- a/ui/src/app/components/object-detail/object-detail.component.html
+++ b/ui/src/app/components/object-detail/object-detail.component.html
@@ -592,7 +592,7 @@
       </div>
     </mat-tab>
 
-    <mat-tab>
+    <mat-tab *ngIf="srcDbName !== 'cassandra'">
       <ng-template mat-tab-label>
         <span>FOREIGN KEY</span>
       </ng-template>

--- a/ui/src/app/services/conversion/conversion.service.spec.ts
+++ b/ui/src/app/services/conversion/conversion.service.spec.ts
@@ -388,5 +388,77 @@ describe('ConversionService', () => {
       },
     ]
     expect(result).toEqual(expected)
-  })  
+  })
+
+  it('getColumnMapping test for new column', () => {
+    let conv: IConv = {} as IConv
+    conv.SrcSchema = {
+      t1: {
+        Name: 'test_table',
+        Id: 't1',
+        Schema: '',
+        ColIds: ['c1'],
+        ColDefs: {
+          c1: {
+            Name: 'src_col',
+            Id: 'c1',
+            Type: { Name: 'text', Mods: [], ArrayBounds: [] },
+            NotNull: false,
+            Ignored: {Check: false, Identity: false, Default: false, Exclusion: false, ForeignKey: false, AutoIncrement: false},
+            DefaultValue: { IsPresent: false, Value: { Statement: '' , ExpressionId: '' } },
+            AutoGen: { Name: '', GenerationType: '' },
+          },
+        },
+        PrimaryKeys: [],
+        ForeignKeys: [],
+        Indexes: [],
+        CheckConstraints: [],
+      },
+    }
+    conv.SpSchema = {
+      t1: {
+        Name: 'test_table',
+        Id: 't1',
+        ColIds: ['c1', 'c2'],
+        ShardIdColumn: '',
+        ColDefs: {
+          c1: {
+            Name: 'sp_col',
+            Id: 'c1',
+            T: { Name: 'STRING', IsArray: false, Len: 255 },
+            NotNull: false,
+            DefaultValue: { IsPresent: false, Value: { Statement: '', ExpressionId: '' } },
+            AutoGen: { Name: '', GenerationType: '' },
+            Opts: {},
+            Comment: '',
+          },
+          c2: {
+            Name: 'new_sp_col',
+            Id: 'c2',
+            T: { Name: 'INT64', IsArray: false, Len: 0 },
+            NotNull: true,
+            DefaultValue: { IsPresent: false, Value: { Statement: '', ExpressionId: '' } },
+            AutoGen: { Name: '', GenerationType: '' },
+            Opts: {},
+            Comment: '',
+          },
+        },
+        PrimaryKeys: [],
+        ForeignKeys: [],
+        Indexes: [],
+        CheckConstraints: [],
+        ParentTable: {} as IInterleavedParent,
+        Comment: '',
+      },
+    }
+    conv.DatabaseType = SourceDbNames.MySQL
+    conv.SpDialect = Dialect.GoogleStandardSQLDialect
+
+    const result = service.getColumnMapping('t1', conv);
+    const expected: IColumnTabData[] = [
+      { spOrder: 1, srcOrder: 1, spColName: 'sp_col', spDataType: 'STRING', srcColName: 'src_col', srcDataType: 'text', spIsPk: false, srcIsPk: false, spIsNotNull: false, srcIsNotNull: false, srcId: 'c1', srcDefaultValue: '', spId: 'c1', spColMaxLength: 255, srcColMaxLength: undefined, spAutoGen: { Name: '', GenerationType: '' }, srcAutoGen: { Name: '', GenerationType: '' }, spDefaultValue: { IsPresent: false, Value: { ExpressionId: '', Statement: '' } }, spCassandraOption: '' },
+      { spOrder: 2, srcOrder: '', spColName: 'new_sp_col', spDataType: 'INT64', srcColName: '', srcDataType: '', spIsPk: false, srcIsPk: false, spIsNotNull: true, srcIsNotNull: false, srcId: '', srcDefaultValue: '', spId: 'c2', spColMaxLength: 0, srcColMaxLength: '', spAutoGen: { Name: '', GenerationType: '' }, srcAutoGen: { Name: '', GenerationType: '' }, spDefaultValue: { IsPresent: false, Value: { ExpressionId: '', Statement: '' } }, spCassandraOption: '' },
+    ]
+    expect(result).toEqual(expected)
+  })
 });

--- a/ui/src/app/services/conversion/conversion.service.ts
+++ b/ui/src/app/services/conversion/conversion.service.ts
@@ -405,7 +405,7 @@ export class ConversionService {
             spId: colId,
             srcColMaxLength: '',
             spColMaxLength: spannerColDef?.T.Len,
-            spCassandraOption: '',
+            spCassandraOption: spannerColDef?.Opts?.["cassandra_type"] || '',
             spAutoGen: spColumn.AutoGen,
             srcAutoGen: {
               Name: '',


### PR DESCRIPTION
### Overview

- Addressed the issue where the length field for ARRAY types is currently not shown in the UI but defaults to MAX for STRING, BYTES, and VARCHAR.
- Session file upload support for Cassandra source.
- Navigation bars for foreign keys and check constraints are currently empty.  Since foreign keys don't exist in Cassandra, the foreign key nav bar is removed in case of Cassandra source.
- Fix for: Cassandra Type Option doesn't show up after adding a new column.