### PR TITLE
Enhance Error Reporting for Cassandra source and Fix Singleton Cluster Configuration Issue

### DIFF
--- a/internal/convert.go
+++ b/internal/convert.go
@@ -148,6 +148,10 @@ const (
 	CheckConstraintFunctionNotFoundError
 	GenericError
 	GenericWarning
+	PrecisionLoss
+	CassandraUUID
+	CassandraTIMEUUID
+	CassandraMAP
 )
 
 const (

--- a/internal/reports/report_helpers.go
+++ b/internal/reports/report_helpers.go
@@ -673,6 +673,10 @@ var IssueDB = map[internal.SchemaIssue]struct {
 	internal.ForeignKeyActionNotSupported: {Brief: "Spanner supports foreign key action migration only for MySQL and PostgreSQL", Severity: warning, Category: "FOREIGN_KEY_ACTIONS"},
 	internal.NumericPKNotSupported:        {Brief: "Spanner PostgreSQL does not support numeric primary keys / unique indices", Severity: warning, Category: "NUMERIC_PK_NOT_SUPPORTED"},
 	internal.DefaultValueError:            {Brief: "Some columns have default value expressions not supported by Spanner. Please fix them to continue migration.", Severity: Errors, batch: true, Category: "INCOMPATIBLE_DEFAULT_VALUE_CONSTRAINTS"},
+	internal.PrecisionLoss:                {Brief: "Numeric only supports (38,9) precision. Be aware of potential precision loss due to type mapping.", Severity: warning, Category: "PRECISION_LOSS"},
+	internal.CassandraUUID:                {Brief: "Cassandra UUIDs map to Spanner's BYTES(16). This generic type doesn't validate UUID versions.", Severity: warning, Category: "CASSANDRA_UUID_USES"},
+	internal.CassandraTIMEUUID:            {Brief: "Cassandra TimeUUIDs map to Spanner's BYTES(16). This generic type doesn't validate embedded timestamps.", Severity: warning, Category: "CASSANDRA_TIMEUUID_USES"},
+	internal.CassandraMAP:                 {Brief: "Cassandra MAP type maps to Spanner's JSON. Spanner does not validate internal JSON structure or types, unlike Cassandra's MAP.", Severity: warning, Category: "CASSANDRA_MAP_USES"},
 }
 
 type Severity int

--- a/sources/cassandra/toddl.go
+++ b/sources/cassandra/toddl.go
@@ -136,19 +136,17 @@ var typeMappings = map[string][]CassandraDdlInfo{
 		},
 	},
 	"DECIMAL": {
-		// TODO: Generate appropriate SchemaIssue to warn of potential data loss
 		{
 			SpannerType:         ddl.Type{Name: ddl.Numeric},
 			CassandraTypeOption: "decimal",
-			Issues:              nil,
+			Issues:              []internal.SchemaIssue{internal.PrecisionLoss},
 		},
 	},
 	"VARINT": {
-		// TODO: Generate appropriate SchemaIssue to warn of potential data loss
 		{
 			SpannerType:         ddl.Type{Name: ddl.Numeric},
 			CassandraTypeOption: "varint",
-			Issues:              nil,
+			Issues:              []internal.SchemaIssue{internal.PrecisionLoss},
 		},
 		{
 			SpannerType:         ddl.Type{Name: ddl.String, Len: ddl.MaxLength},
@@ -197,8 +195,6 @@ var typeMappings = map[string][]CassandraDdlInfo{
 			Issues:              []internal.SchemaIssue{internal.Widened},
 		},
 	},
-	// TODO: Generate appropriate SchemaIssue to warn 
-	// that the field might acceept UUID of unsupported versions as compared to Cassandra.
 	"UUID": {
 		{
 			SpannerType:         ddl.Type{Name: ddl.String, Len: ddl.MaxLength},
@@ -208,11 +204,9 @@ var typeMappings = map[string][]CassandraDdlInfo{
 		{
 			SpannerType:         ddl.Type{Name: ddl.Bytes, Len: 16},
 			CassandraTypeOption: "uuid",
-			Issues:              []internal.SchemaIssue{internal.Widened},
+			Issues:              []internal.SchemaIssue{internal.CassandraUUID},
 		},
 	},
-	// TODO: Generate appropriate SchemaIssue to warn 
-	// that the field might acceept TIMEUUID of unsupported versions as compared to Cassandra.
 	"TIMEUUID": {
 		{
 			SpannerType:         ddl.Type{Name: ddl.String, Len: ddl.MaxLength},
@@ -222,7 +216,7 @@ var typeMappings = map[string][]CassandraDdlInfo{
 		{
 			SpannerType:         ddl.Type{Name: ddl.Bytes, Len: 16},
 			CassandraTypeOption: "timeuuid",
-			Issues:              []internal.SchemaIssue{internal.Widened},
+			Issues:              []internal.SchemaIssue{internal.CassandraTIMEUUID},
 		},
 	},
 	"INET": {
@@ -281,7 +275,6 @@ var typeMappings = map[string][]CassandraDdlInfo{
 		},
 	},
 	"DURATION": {
-		// TODO: Generate appropriate SchemaIssue to warn about adapter not supporting duration
 		{
 			SpannerType:         ddl.Type{Name: ddl.String, Len: ddl.MaxLength},
 			CassandraTypeOption: "text",
@@ -306,11 +299,10 @@ var typeMappings = map[string][]CassandraDdlInfo{
 		},
 	},
 	"COUNTER": {
-		// TODO: Generate appropriate SchemaIssue to warn about adapter not supporting counter
 		{
 			SpannerType:         ddl.Type{Name: ddl.Int64},
 			CassandraTypeOption: "counter",
-			Issues:              nil,
+			Issues:              []internal.SchemaIssue{internal.NoGoodType},
 		},
 	},
 }
@@ -345,7 +337,6 @@ func (m *CassandraTypeMapper) getMapping(cassandraTypeName string, spTypeName st
 		}
 		return mappings[0], true
 	}
-    // TODO: Generate appropriate SchemaIssue to warn about conversion from map to JSON
     // Handles map collection type
     if mapMatch := mapRegex.FindStringSubmatch(s); len(mapMatch) > 0 {
 		KeyTypeName := strings.TrimSpace(mapMatch[1])
@@ -383,7 +374,7 @@ func (m *CassandraTypeMapper) getMapping(cassandraTypeName string, spTypeName st
 
         newCassandraTypeOption := "map<" + KeyTypeOption + "," + ValueTypeOption + ">"
 
-        issues := []internal.SchemaIssue{}
+        issues := []internal.SchemaIssue{internal.CassandraMAP}
         if hasIssue {
             issues = append(issues, internal.NoGoodType)
         }

--- a/sources/cassandra/toddl_test.go
+++ b/sources/cassandra/toddl_test.go
@@ -187,12 +187,14 @@ func TestCassandraTypeMapper(t *testing.T) {
 			cassandraType:       "decimal",
 			expectedSpannerType: ddl.Type{Name: ddl.Numeric},
 			expectedOption:      "decimal",
+			expectedIssues:      []internal.SchemaIssue{internal.PrecisionLoss},
 		},
 		{
 			name:                "Default varint",
 			cassandraType:       "varint",
 			expectedSpannerType: ddl.Type{Name: ddl.Numeric},
 			expectedOption:      "varint",
+			expectedIssues:      []internal.SchemaIssue{internal.PrecisionLoss},
 		},
 		{
 			name:                "Override varint to STRING",
@@ -264,7 +266,7 @@ func TestCassandraTypeMapper(t *testing.T) {
 			userSpannerType:     ddl.Bytes,
 			expectedSpannerType: ddl.Type{Name: ddl.Bytes, Len: 16},
 			expectedOption:      "uuid",
-			expectedIssues:      []internal.SchemaIssue{internal.Widened},
+			expectedIssues:      []internal.SchemaIssue{internal.CassandraUUID},
 		},
 		{
 			name:                "Default timeuuid",
@@ -278,7 +280,7 @@ func TestCassandraTypeMapper(t *testing.T) {
 			userSpannerType:     ddl.Bytes,
 			expectedSpannerType: ddl.Type{Name: ddl.Bytes, Len: 16},
 			expectedOption:      "timeuuid",
-			expectedIssues:      []internal.SchemaIssue{internal.Widened},
+			expectedIssues:      []internal.SchemaIssue{internal.CassandraTIMEUUID},
 		},
 		{
 			name:                "Default inet",
@@ -377,6 +379,7 @@ func TestCassandraTypeMapper(t *testing.T) {
 			cassandraType:       "counter",
 			expectedSpannerType: ddl.Type{Name: ddl.Int64},
 			expectedOption:      "counter",
+			expectedIssues:      []internal.SchemaIssue{internal.NoGoodType},
 		},
 		{
 			name:                "List Type",
@@ -396,20 +399,21 @@ func TestCassandraTypeMapper(t *testing.T) {
 			cassandraType:       "map<text,int>",
 			expectedSpannerType: ddl.Type{Name: ddl.JSON},
 			expectedOption:      "map<text,int>",
+			expectedIssues:      []internal.SchemaIssue{internal.CassandraMAP},
 		},
 		{
 			name:                "Unsupported types in map",
 			cassandraType:       "map<udt, duration>",
 			expectedSpannerType: ddl.Type{Name: ddl.JSON},
 			expectedOption:      "map<text,text>",
-			expectedIssues:      []internal.SchemaIssue{internal.NoGoodType},
+			expectedIssues:      []internal.SchemaIssue{internal.CassandraMAP, internal.NoGoodType},
 		},
 		{
 			name:                "Unsupported types in map",
 			cassandraType:       "map<duration, udt>",
 			expectedSpannerType: ddl.Type{Name: ddl.JSON},
 			expectedOption:      "map<text,text>",
-			expectedIssues:      []internal.SchemaIssue{internal.NoGoodType},
+			expectedIssues:      []internal.SchemaIssue{internal.CassandraMAP, internal.NoGoodType},
 		},
 		{
 			name:                "Fallback Nested List",


### PR DESCRIPTION
### Overview

- Fixed an issue where the accessor (which pings and connects) currently uses `sync.Once` to configure the cluster. Previously, if a user entered incorrect details initially, new details wouldn't be re-taken. This is resolved by replacing sync.Once with a `sync.Mutex` to ensure thread safety.
- SMT now generates correct warnings (precision loss, UUID validation, map type map to JSON etc.)  in the Error Report for Cassandra Source