### PR TITLE
Fixing varbinary (varbinary(XX)) schema migration for mysql to map to correct spanner type with length BYTES(XX)

### DIFF
--- a/sources/mysql/toddl.go
+++ b/sources/mysql/toddl.go
@@ -193,6 +193,9 @@ func toSpannerTypeInternal(srcType schema.Type, spType string) (ddl.Type, []inte
 		case ddl.String:
 			return ddl.Type{Name: ddl.String, Len: ddl.MaxLength}, nil
 		default:
+			if len(srcType.Mods) > 0 {
+				return ddl.Type{Name: ddl.Bytes, Len: srcType.Mods[0]}, nil
+			}
 			return ddl.Type{Name: ddl.Bytes, Len: ddl.MaxLength}, nil
 		}
 	case "tinyblob", "mediumblob", "blob", "longblob":

--- a/sources/mysql/toddl_test.go
+++ b/sources/mysql/toddl_test.go
@@ -103,6 +103,13 @@ func TestToSpannerTypeInternal(t *testing.T) {
 	if errCheck != nil {
 		t.Errorf("Error in binary to default conversion")
 	}
+	spType, errCheck := toSpannerTypeInternal(schema.Type{"varbinary", []int64{10}, []int64{}}, "BYTES")
+	if errCheck != nil {
+		t.Errorf("Error in binary to default conversion")
+	}
+	assert.Equal(t, "BYTES", spType.Name)
+	assert.Equal(t, int64(10), spType.Len)
+	assert.Equal(t, false, spType.IsArray)
 	_, errCheck = toSpannerTypeInternal(schema.Type{"blob", []int64{1, 2, 3}, []int64{1, 2, 3}}, "STRING")
 	if errCheck != nil {
 		t.Errorf("Error in blob to string conversion")


### PR DESCRIPTION

Fixes #<issue_number_goes_here>

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to README are included in PR