### PR TITLE
Upgrade Go to 1.24 in Dockerfile

### DIFF
--- a/sources/cassandra/Dockerfile
+++ b/sources/cassandra/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23-bullseye AS builder
+FROM golang:1.24-bullseye AS builder
 
 # Disable cgo to remove gcc dependency
 ENV CGO_ENABLED=0


### PR DESCRIPTION
Update Go to 1.24 for ZDM proxy requirements in Dockerfile.