### PR TITLE
Fixing binary schema migration for mysql to map to correct spanner type with length BYTES(XX)

### DIFF
--- a/sources/mysql/mysqldump_test.go
+++ b/sources/mysql/mysqldump_test.go
@@ -70,7 +70,7 @@ func TestProcessMySQLDump_Scalar(t *testing.T) {
 		{"enum('a','b')", ddl.Type{Name: ddl.String, Len: ddl.MaxLength}},
 		{"timestamp", ddl.Type{Name: ddl.Timestamp}},
 		{"datetime", ddl.Type{Name: ddl.Timestamp}},
-		{"binary", ddl.Type{Name: ddl.Bytes, Len: ddl.MaxLength}},
+		{"binary", ddl.Type{Name: ddl.Bytes, Len: int64(1)}},
 		{"varchar(42)", ddl.Type{Name: ddl.String, Len: int64(42)}},
 	}
 	for _, tc := range scalarTests {

--- a/sources/mysql/toddl.go
+++ b/sources/mysql/toddl.go
@@ -188,14 +188,7 @@ func toSpannerTypeInternal(srcType schema.Type, spType string) (ddl.Type, []inte
 		default:
 			return ddl.Type{Name: ddl.JSON}, nil
 		}
-	case "binary":
-		switch spType {
-		case ddl.String:
-			return ddl.Type{Name: ddl.String, Len: ddl.MaxLength}, nil
-		default:
-			return ddl.Type{Name: ddl.Bytes, Len: ddl.MaxLength}, nil
-		}
-	case "varbinary":
+	case "binary", "varbinary":
 		switch spType {
 		case ddl.String:
 			return ddl.Type{Name: ddl.String, Len: ddl.MaxLength}, nil

--- a/sources/mysql/toddl_test.go
+++ b/sources/mysql/toddl_test.go
@@ -105,10 +105,17 @@ func TestToSpannerTypeInternal(t *testing.T) {
 	}
 	spType, errCheck := toSpannerTypeInternal(schema.Type{"varbinary", []int64{10}, []int64{}}, "BYTES")
 	if errCheck != nil {
-		t.Errorf("Error in binary to default conversion")
+		t.Errorf("Error in varbinary to default conversion")
 	}
 	assert.Equal(t, "BYTES", spType.Name)
 	assert.Equal(t, int64(10), spType.Len)
+	assert.Equal(t, false, spType.IsArray)
+	spType, errCheck = toSpannerTypeInternal(schema.Type{"binary", []int64{12}, []int64{}}, "BYTES")
+	if errCheck != nil {
+		t.Errorf("Error in binary to default conversion")
+	}
+	assert.Equal(t, "BYTES", spType.Name)
+	assert.Equal(t, int64(12), spType.Len)
 	assert.Equal(t, false, spType.IsArray)
 	_, errCheck = toSpannerTypeInternal(schema.Type{"blob", []int64{1, 2, 3}, []int64{1, 2, 3}}, "STRING")
 	if errCheck != nil {


### PR DESCRIPTION

Fixes #<issue_number_goes_here>

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to README are included in PR