### PR TITLE
fix for handling special characters in connection fields

### DIFF
--- a/profiles/common.go
+++ b/profiles/common.go
@@ -29,6 +29,7 @@ import (
 // input string is of the form "key1=value1,key2=value2,..." etc. Return error
 // otherwise.
 func ParseMap(s string) (map[string]string, error) {
+	fmt.Println("Complete string", s)
 	params := make(map[string]string)
 	if len(s) == 0 {
 		return params, nil
@@ -49,20 +50,28 @@ func ParseMap(s string) (map[string]string, error) {
 	}
 
 	for _, kv := range records[0] {
-		s := strings.Split(strings.TrimSpace(kv), "=")
-		if len(s) != 2 {
+		equalSignIndex := strings.Index(kv, "=")
+		if equalSignIndex == -1 {
 			return params, fmt.Errorf("invalid key=value pair (expected format: key1=value1): %v", kv)
 		}
-		if _, ok := params[s[0]]; ok {
-			return params, fmt.Errorf("duplicate key found: %v", s[0])
+
+		key := strings.TrimSpace(kv[:equalSignIndex])
+		value := kv[equalSignIndex+1:]
+
+		if len(key) == 0 {
+			return params, fmt.Errorf("empty key found in pair: %v", kv)
 		}
-		params[s[0]] = s[1]
+
+		if _, ok := params[key]; ok {
+			return params, fmt.Errorf("duplicate key found: %v", key)
+		}
+		params[key] = value
 	}
 	return params, nil
 }
 
-func ParseList(s string)([]string, error) {
-	if (len(s) == 0) {
+func ParseList(s string) ([]string, error) {
+	if len(s) == 0 {
 		return nil, nil
 	}
 	r := csv.NewReader(strings.NewReader(s))

--- a/profiles/common.go
+++ b/profiles/common.go
@@ -29,7 +29,6 @@ import (
 // input string is of the form "key1=value1,key2=value2,..." etc. Return error
 // otherwise.
 func ParseMap(s string) (map[string]string, error) {
-	fmt.Println("Complete string", s)
 	params := make(map[string]string)
 	if len(s) == 0 {
 		return params, nil

--- a/profiles/common_test.go
+++ b/profiles/common_test.go
@@ -24,40 +24,52 @@ import (
 func TestParseMap(t *testing.T) {
 	// Avoid getting/setting env variables in the unit tests.
 	testCases := []struct {
-		name          string
-		inputString   string
-		expectedParams  map[string]string
-		errorExpected bool
+		name           string
+		inputString    string
+		expectedParams map[string]string
+		errorExpected  bool
 	}{
 		{
-			name:          		"empty params",
-			inputString:   		"",
-			expectedParams: 	map[string]string{},
-			errorExpected: 		false,
+			name:           "empty params",
+			inputString:    "",
+			expectedParams: map[string]string{},
+			errorExpected:  false,
 		},
 		{
-			name:          		"valid params=",
-			inputString:   		"instance=instance",
-			expectedParams: 	map[string]string{"instance": "instance"},
-			errorExpected: 		false,
+			name:           "valid params",
+			inputString:    "instance=instance",
+			expectedParams: map[string]string{"instance": "instance"},
+			errorExpected:  false,
 		},
 		{
-			name:          		"invalid params incorrect format",
-			inputString:   		"uuwy",
-			expectedParams: 	map[string]string{},
-			errorExpected: 		true,
+			name:           "valid params with = in value",
+			inputString:    "password=pass=word",
+			expectedParams: map[string]string{"password": "pass=word"},
+			errorExpected:  false,
 		},
 		{
-			name:          		"invalid params new line char",
-			inputString:   		"uuwy\n hjgse",
-			expectedParams: 	map[string]string{},
-			errorExpected: 		true,
+			name:           "valid params with special characters in value",
+			inputString:    "\"password=password`~!@#$%^&*()-_=+[]{}|;:<,>.?/'\\\"",
+			expectedParams: map[string]string{"password": "password`~!@#$%^&*()-_=+[]{}|;:<,>.?/'\\"},
+			errorExpected:  false,
 		},
 		{
-			name:          		"invalid params duplicates",
-			inputString:   		"instance=instance, instance=instance",
-			expectedParams: 	map[string]string{"instance": "instance"},
-			errorExpected: 		true,
+			name:           "invalid params incorrect format",
+			inputString:    "uuwy",
+			expectedParams: map[string]string{},
+			errorExpected:  true,
+		},
+		{
+			name:           "invalid params new line char",
+			inputString:    "uuwy\n hjgse",
+			expectedParams: map[string]string{},
+			errorExpected:  true,
+		},
+		{
+			name:           "invalid params duplicates",
+			inputString:    "instance=instance, instance=instance",
+			expectedParams: map[string]string{"instance": "instance"},
+			errorExpected:  true,
 		},
 	}
 
@@ -68,33 +80,32 @@ func TestParseMap(t *testing.T) {
 	}
 }
 
-
 // code for testing parse list
 func TestParseList(t *testing.T) {
 	// Avoid getting/setting env variables in the unit tests.
 	testCases := []struct {
-		name            string
-		inputString     string
-		expectedParams  []string
-		errorExpected   bool
+		name           string
+		inputString    string
+		expectedParams []string
+		errorExpected  bool
 	}{
 		{
-			name:          		"empty input string",
-			inputString:   		"",
-			expectedParams: 	nil,
-			errorExpected: 		false,
+			name:           "empty input string",
+			inputString:    "",
+			expectedParams: nil,
+			errorExpected:  false,
 		},
 		{
-			name:          		"valid input string",
-			inputString:   		"hello, world",
-			expectedParams: 	[]string{"hello","world"},
-			errorExpected: 		false,
+			name:           "valid input string",
+			inputString:    "hello, world",
+			expectedParams: []string{"hello", "world"},
+			errorExpected:  false,
 		},
 		{
-			name:          		"invalid input string new line char",
-			inputString:   		"hello, world\n, !",
-			expectedParams: 	nil,
-			errorExpected: 		true,
+			name:           "invalid input string new line char",
+			inputString:    "hello, world\n, !",
+			expectedParams: nil,
+			errorExpected:  true,
 		},
 	}
 
@@ -114,72 +125,72 @@ func TestGetSQLConnectionStr(t *testing.T) {
 	pwd := "password"
 	db := "database"
 	testCases := []struct {
-		name            		string
-		inputSourceProfileConn  SourceProfileConnection
-		expectedOutput			string
+		name                   string
+		inputSourceProfileConn SourceProfileConnection
+		expectedOutput         string
 	}{
 		{
-			name:          			"source profile connection type mysql",
+			name:                   "source profile connection type mysql",
 			inputSourceProfileConn: SourceProfileConnection{Ty: SourceProfileConnectionTypeMySQL, Mysql: SourceProfileConnectionMySQL{Host: host, Port: port, User: user, Pwd: pwd, Db: db}},
-			expectedOutput:			"user:password@tcp(0.0.0.0:3306)/database",
+			expectedOutput:         "user:password@tcp(0.0.0.0:3306)/database",
 		},
 		{
-			name:          			"source profile connection type postgres",
+			name:                   "source profile connection type postgres",
 			inputSourceProfileConn: SourceProfileConnection{Ty: SourceProfileConnectionTypePostgreSQL, Pg: SourceProfileConnectionPostgreSQL{Host: host, Port: port, User: user, Pwd: pwd, Db: db}},
-			expectedOutput:			"host=0.0.0.0 port=3306 user=user password=password dbname=database sslmode=disable",
+			expectedOutput:         "host=0.0.0.0 port=3306 user=user password=password dbname=database sslmode=disable",
 		},
 		{
-			name:          			"source profile connection type dynamodb",
+			name:                   "source profile connection type dynamodb",
 			inputSourceProfileConn: SourceProfileConnection{Ty: SourceProfileConnectionTypeDynamoDB},
-			expectedOutput:			"",
+			expectedOutput:         "",
 		},
 		{
-			name:          			"source profile connection type sql server",
+			name:                   "source profile connection type sql server",
 			inputSourceProfileConn: SourceProfileConnection{Ty: SourceProfileConnectionTypeSqlServer, SqlServer: SourceProfileConnectionSqlServer{Host: host, Port: port, User: user, Pwd: pwd, Db: db}},
-			expectedOutput:			"sqlserver://user:password@0.0.0.0:3306?database=database",
+			expectedOutput:         "sqlserver://user:password@0.0.0.0:3306?database=database",
 		},
 		{
-			name:          			"source profile connection type oracle",
+			name:                   "source profile connection type oracle",
 			inputSourceProfileConn: SourceProfileConnection{Ty: SourceProfileConnectionTypeOracle, Oracle: SourceProfileConnectionOracle{Host: host, Port: port, User: user, Pwd: pwd, Db: db}},
-			expectedOutput:			"oracle://user:password@0.0.0.0:3306/database",
+			expectedOutput:         "oracle://user:password@0.0.0.0:3306/database",
 		},
 	}
 
 	for _, tc := range testCases {
-		res:= GetSQLConnectionStr(SourceProfile{Ty: SourceProfileType(SourceProfileTypeConnection), Conn: tc.inputSourceProfileConn})
+		res := GetSQLConnectionStr(SourceProfile{Ty: SourceProfileType(SourceProfileTypeConnection), Conn: tc.inputSourceProfileConn})
 		assert.Equal(t, tc.expectedOutput, res, tc.name)
 	}
 }
 
 func TestGenerateConnectionStr(t *testing.T) {
 	// Avoid getting/setting env variables in the unit tests.
-	before := func(){
+	before := func() {
 		setEnvVariables()
 	}
 
-	after := func(){
+	after := func() {
 		unsetEnvVariables()
 	}
 	testCases := []struct {
-		name            			string
-		expectedOutputPg			string
-		expectedOutputMysql			string
-		errorExpected				bool
+		name                string
+		expectedOutputPg    string
+		expectedOutputMysql string
+		errorExpected       bool
 	}{
 		{
-			name:          				"valid get mysql and postgres conn string",
-			expectedOutputPg:			"host=0.0.0.0 port=3306 user=user password=password dbname=db sslmode=disable",
-			expectedOutputMysql:		"user:password@tcp(0.0.0.0:3306)/db",
-			errorExpected: 				false,
+			name:                "valid get mysql and postgres conn string",
+			expectedOutputPg:    "host=0.0.0.0 port=3306 user=user password=password dbname=db sslmode=disable",
+			expectedOutputMysql: "user:password@tcp(0.0.0.0:3306)/db",
+			errorExpected:       false,
 		},
 	}
 
 	for _, tc := range testCases {
 		before()
-		res, err:= GeneratePGSQLConnectionStr()
+		res, err := GeneratePGSQLConnectionStr()
 		assert.Equal(t, tc.expectedOutputPg, res, tc.name)
 		assert.Equal(t, tc.errorExpected, err != nil, tc.name)
-		res, err= GenerateMYSQLConnectionStr()
+		res, err = GenerateMYSQLConnectionStr()
 		assert.Equal(t, tc.expectedOutputMysql, res, tc.name)
 		assert.Equal(t, tc.errorExpected, err != nil, tc.name)
 		after()
@@ -189,19 +200,19 @@ func TestGenerateConnectionStr(t *testing.T) {
 func TestGetSchemaSampleSize(t *testing.T) {
 	// Avoid getting/setting env variables in the unit tests.
 	testCases := []struct {
-		name            			string
-		inputSourceProfile			SourceProfile
-		expectedOutput				int64
+		name               string
+		inputSourceProfile SourceProfile
+		expectedOutput     int64
 	}{
 		{
-			name:          				"mysql source profile type",
-			inputSourceProfile: 		SourceProfile{Ty: SourceProfileType(SourceProfileTypeConnection), Conn: SourceProfileConnection{Ty: SourceProfileConnectionTypeMySQL}},
-			expectedOutput:				int64(100000),
+			name:               "mysql source profile type",
+			inputSourceProfile: SourceProfile{Ty: SourceProfileType(SourceProfileTypeConnection), Conn: SourceProfileConnection{Ty: SourceProfileConnectionTypeMySQL}},
+			expectedOutput:     int64(100000),
 		},
 		{
-			name:          				"dynamo db source profile type",
-			inputSourceProfile: 		SourceProfile{Ty: SourceProfileType(SourceProfileTypeConnection), Conn: SourceProfileConnection{Ty: SourceProfileConnectionTypeDynamoDB, Dydb: SourceProfileConnectionDynamoDB{SchemaSampleSize: int64(5000)}}},
-			expectedOutput:				int64(5000),
+			name:               "dynamo db source profile type",
+			inputSourceProfile: SourceProfile{Ty: SourceProfileType(SourceProfileTypeConnection), Conn: SourceProfileConnection{Ty: SourceProfileConnectionTypeDynamoDB, Dydb: SourceProfileConnectionDynamoDB{SchemaSampleSize: int64(5000)}}},
+			expectedOutput:     int64(5000),
 		},
 	}
 

--- a/webv2/web.go
+++ b/webv2/web.go
@@ -33,10 +33,10 @@ import (
 	"time"
 
 	instance "cloud.google.com/go/spanner/admin/instance/apiv1"
+	cassandraaccessor "github.com/GoogleCloudPlatform/spanner-migration-tool/accessors/cassandra"
 	cc "github.com/GoogleCloudPlatform/spanner-migration-tool/accessors/clients/cassandra"
 	storageclient "github.com/GoogleCloudPlatform/spanner-migration-tool/accessors/clients/storage"
 	storageaccessor "github.com/GoogleCloudPlatform/spanner-migration-tool/accessors/storage"
-	"github.com/GoogleCloudPlatform/spanner-migration-tool/accessors/cassandra"
 	"github.com/GoogleCloudPlatform/spanner-migration-tool/cmd"
 	"github.com/GoogleCloudPlatform/spanner-migration-tool/common/constants"
 	"github.com/GoogleCloudPlatform/spanner-migration-tool/common/utils"
@@ -830,7 +830,7 @@ func getSourceAndTargetProfiles(sessionState *session.SessionState, details type
 			return profiles.SourceProfile{}, profiles.TargetProfile{}, utils.IOStreams{}, "", fmt.Errorf("error while creating config to initiate sharded migration:%v", err)
 		}
 	} else if sessionState.Driver == constants.CASSANDRA {
-		sourceProfileString = fmt.Sprintf("host=%v,port=%v,user=%v,password=%v,keyspace=%v,datacenter=%v",
+		sourceProfileString = fmt.Sprintf("\"host=%v\",\"port=%v\",\"user=%v\",\"password=%v\",\"keyspace=%v\",\"datacenter=%v\"",
 			sourceDBConnectionDetails.Host,
 			sourceDBConnectionDetails.Port,
 			sourceDBConnectionDetails.User,
@@ -838,7 +838,7 @@ func getSourceAndTargetProfiles(sessionState *session.SessionState, details type
 			sessionState.DbName,
 			sourceDBConnectionDetails.DataCenter)
 	} else {
-		sourceProfileString = fmt.Sprintf("host=%v,port=%v,user=%v,password=%v,dbName=%v",
+		sourceProfileString = fmt.Sprintf("\"host=%v\",\"port=%v\",\"user=%v\",\"password=%v\",\"dbName=%v\"",
 			sourceDBConnectionDetails.Host, sourceDBConnectionDetails.Port, sourceDBConnectionDetails.User,
 			sourceDBConnectionDetails.Password, sessionState.DbName)
 	}


### PR DESCRIPTION
Please note that this doesn't solve for `"` in any of the fields. We will have to imply another solution like using json in such a case.