### PR TITLE
Added access token client options. This will enable Gcloud to pass access token via Environment variable.

### DIFF
--- a/accessors/clients/client_options.go
+++ b/accessors/clients/client_options.go
@@ -1,0 +1,41 @@
+package clients
+
+import (
+	"golang.org/x/oauth2"
+	"google.golang.org/api/option"
+	"os"
+)
+
+func FetchSpannerClientOptions() []option.ClientOption {
+	var clientOptions []option.ClientOption
+	if endpoint := os.Getenv("SPANNER_API_ENDPOINT"); endpoint != "" {
+		clientOptions = append(clientOptions, option.WithEndpoint(endpoint))
+	}
+	authOption := fetchAuthClientOptions()
+	if authOption != nil {
+		clientOptions = append(clientOptions, authOption)
+	}
+	return clientOptions
+}
+
+func FetchStorageClientOptions() []option.ClientOption {
+	var clientOptions []option.ClientOption
+	authOption := fetchAuthClientOptions()
+	if authOption != nil {
+		clientOptions = append(clientOptions, authOption)
+	}
+	return clientOptions
+}
+
+func fetchAuthClientOptions() option.ClientOption {
+
+	if gcloudAuthPlugin := os.Getenv("GCLOUD_AUTH_PLUGIN"); gcloudAuthPlugin == "true" {
+		// Wrap the token with cloud.google.com/go/auth.Credentials.
+		tokenFromSource := option.WithTokenSource(oauth2.StaticTokenSource(&oauth2.Token{
+			AccessToken: os.Getenv("GCLOUD_AUTH_ACCESS_TOKEN"),
+		}))
+
+		return tokenFromSource
+	}
+	return nil
+}

--- a/accessors/clients/client_options_test.go
+++ b/accessors/clients/client_options_test.go
@@ -1,0 +1,159 @@
+package clients
+
+import (
+	"testing"
+)
+
+func TestFetchSpannerClientOptions(t *testing.T) {
+	tests := []struct {
+		name                 string
+		spannerApiEndpoint   string
+		gcloudAuthPlugin     string
+		gcloudAuthToken      string
+		expectedOptionsCount int
+	}{
+		{
+			name:                 "No env vars set",
+			expectedOptionsCount: 0,
+		},
+		{
+			name:                 "Only SPANNER_API_ENDPOINT set",
+			spannerApiEndpoint:   "localhost:9010",
+			expectedOptionsCount: 1,
+		},
+		{
+			name:                 "Only GCLOUD_AUTH_PLUGIN set to true",
+			gcloudAuthPlugin:     "true",
+			gcloudAuthToken:      "test-token",
+			expectedOptionsCount: 1,
+		},
+		{
+			name:                 "Both SPANNER_API_ENDPOINT and GCLOUD_AUTH_PLUGIN set",
+			spannerApiEndpoint:   "localhost:9010",
+			gcloudAuthPlugin:     "true",
+			gcloudAuthToken:      "test-token",
+			expectedOptionsCount: 2,
+		},
+		{
+			name:                 "GCLOUD_AUTH_PLUGIN set to false",
+			gcloudAuthPlugin:     "false",
+			expectedOptionsCount: 0,
+		},
+		{
+			name:                 "SPANNER_API_ENDPOINT set and GCLOUD_AUTH_PLUGIN is false",
+			spannerApiEndpoint:   "localhost:9010",
+			gcloudAuthPlugin:     "false",
+			expectedOptionsCount: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.spannerApiEndpoint != "" {
+				t.Setenv("SPANNER_API_ENDPOINT", tt.spannerApiEndpoint)
+			}
+			if tt.gcloudAuthPlugin != "" {
+				t.Setenv("GCLOUD_AUTH_PLUGIN", tt.gcloudAuthPlugin)
+			}
+			if tt.gcloudAuthToken != "" {
+				t.Setenv("GCLOUD_AUTH_ACCESS_TOKEN", tt.gcloudAuthToken)
+			}
+
+			opts := FetchSpannerClientOptions()
+			if len(opts) != tt.expectedOptionsCount {
+				t.Errorf("FetchSpannerClientOptions() returned %d options, want %d", len(opts), tt.expectedOptionsCount)
+			}
+		})
+	}
+}
+
+func TestFetchStorageClientOptions(t *testing.T) {
+	tests := []struct {
+		name                 string
+		gcloudAuthPlugin     string
+		gcloudAuthToken      string
+		expectedOptionsCount int
+	}{
+		{
+			name:                 "No auth env vars set",
+			expectedOptionsCount: 0,
+		},
+		{
+			name:                 "GCLOUD_AUTH_PLUGIN set to true",
+			gcloudAuthPlugin:     "true",
+			gcloudAuthToken:      "test-token",
+			expectedOptionsCount: 1,
+		},
+		{
+			name:                 "GCLOUD_AUTH_PLUGIN set to false",
+			gcloudAuthPlugin:     "false",
+			expectedOptionsCount: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.gcloudAuthPlugin != "" {
+				t.Setenv("GCLOUD_AUTH_PLUGIN", tt.gcloudAuthPlugin)
+			}
+			if tt.gcloudAuthToken != "" {
+				t.Setenv("GCLOUD_AUTH_ACCESS_TOKEN", tt.gcloudAuthToken)
+			}
+
+			opts := FetchStorageClientOptions()
+			if len(opts) != tt.expectedOptionsCount {
+				t.Errorf("FetchStorageClientOptions() returned %d options, want %d", len(opts), tt.expectedOptionsCount)
+			}
+		})
+	}
+}
+
+func TestFetchAuthClientOptions(t *testing.T) {
+	tests := []struct {
+		name             string
+		gcloudAuthPlugin string
+		gcloudAuthToken  string
+		expectNil        bool
+	}{
+		{
+			name:      "GCLOUD_AUTH_PLUGIN not set",
+			expectNil: true,
+		},
+		{
+			name:             "GCLOUD_AUTH_PLUGIN is true",
+			gcloudAuthPlugin: "true",
+			gcloudAuthToken:  "test-token",
+			expectNil:        false,
+		},
+		{
+			name:             "GCLOUD_AUTH_PLUGIN is false",
+			gcloudAuthPlugin: "false",
+			expectNil:        true,
+		},
+		{
+			name:             "GCLOUD_AUTH_PLUGIN is true but no token",
+			gcloudAuthPlugin: "true",
+			expectNil:        false, // The function still returns an option, even if the token is empty.
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.gcloudAuthPlugin != "" {
+				t.Setenv("GCLOUD_AUTH_PLUGIN", tt.gcloudAuthPlugin)
+			}
+			if tt.gcloudAuthToken != "" {
+				t.Setenv("GCLOUD_AUTH_ACCESS_TOKEN", tt.gcloudAuthToken)
+			}
+
+			opt := fetchAuthClientOptions()
+
+			if tt.expectNil && opt != nil {
+				t.Errorf("fetchAuthClientOptions() returned a non-nil option, want nil")
+			}
+			if !tt.expectNil && opt == nil {
+				t.Errorf("fetchAuthClientOptions() returned a nil option, want non-nil")
+			}
+		})
+	}
+}

--- a/accessors/clients/spanner/admin/admin_client.go
+++ b/accessors/clients/spanner/admin/admin_client.go
@@ -19,6 +19,7 @@ import (
 	"sync"
 
 	database "cloud.google.com/go/spanner/admin/database/apiv1"
+	"github.com/GoogleCloudPlatform/spanner-migration-tool/accessors/clients"
 )
 
 var once sync.Once
@@ -32,7 +33,8 @@ func GetOrCreateClient(ctx context.Context) (*database.DatabaseAdminClient, erro
 	var err error
 	if spannerAdminClient == nil {
 		once.Do(func() {
-			spannerAdminClient, err = newDatabaseAdminClient(ctx)
+			clientOptions := clients.FetchSpannerClientOptions()
+			spannerAdminClient, err = newDatabaseAdminClient(ctx, clientOptions...)
 		})
 		if err != nil {
 			return nil, fmt.Errorf("failed to create spanner admin client: %v", err)

--- a/accessors/clients/spanner/admin/admin_client_test.go
+++ b/accessors/clients/spanner/admin/admin_client_test.go
@@ -54,6 +54,22 @@ func TestGetOrCreateClient_Basic(t *testing.T) {
 	assert.Nil(t, err)
 }
 
+func TestGetOrCreateClient_ClientOpts(t *testing.T) {
+	resetTest()
+	ctx := context.Background()
+	_ = os.Setenv("GCLOUD_AUTH_PLUGIN", "true")
+	_ = os.Setenv("GCLOUD_AUTH_ACCESS_TOKEN", "access-token")
+	oldFunc := newDatabaseAdminClient
+	defer func() { newDatabaseAdminClient = oldFunc }()
+	newDatabaseAdminClient = func(ctx context.Context, opts ...option.ClientOption) (*database.DatabaseAdminClient, error) {
+		assert.Equal(t, len(opts), 1)
+		return &database.DatabaseAdminClient{}, nil
+	}
+	c, err := GetOrCreateClient(ctx)
+	assert.NotNil(t, c)
+	assert.Nil(t, err)
+}
+
 func TestGetOrCreateClient_OnlyOnceViaSync(t *testing.T) {
 	resetTest()
 	ctx := context.Background()

--- a/accessors/clients/spanner/client/spanner_client.go
+++ b/accessors/clients/spanner/client/spanner_client.go
@@ -19,6 +19,7 @@ import (
 	"sync"
 
 	sp "cloud.google.com/go/spanner"
+	"github.com/GoogleCloudPlatform/spanner-migration-tool/accessors/clients"
 )
 
 var once sync.Once
@@ -32,7 +33,8 @@ func GetOrCreateClient(ctx context.Context, dbURI string) (*sp.Client, error) {
 	var err error
 	if spannerClient == nil {
 		once.Do(func() {
-			spannerClient, err = newClient(ctx, dbURI)
+			clientOptions := clients.FetchSpannerClientOptions()
+			spannerClient, err = newClient(ctx, dbURI, clientOptions...)
 		})
 		if err != nil {
 			return nil, fmt.Errorf("failed to create spanner database client: %v", err)
@@ -44,7 +46,8 @@ func GetOrCreateClient(ctx context.Context, dbURI string) (*sp.Client, error) {
 
 func CreateClient(ctx context.Context, dbURI string) (*sp.Client, error) {
 	var err error
-	spannerClient, err = newClient(ctx, dbURI)
+	clientOptions := clients.FetchSpannerClientOptions()
+	spannerClient, err = newClient(ctx, dbURI, clientOptions...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create spanner database client: %v", err)
 	}

--- a/accessors/clients/spanner/client/spanner_client_test.go
+++ b/accessors/clients/spanner/client/spanner_client_test.go
@@ -54,6 +54,22 @@ func TestGetOrCreateClient_Basic(t *testing.T) {
 	assert.Nil(t, err)
 }
 
+func TestGetOrCreateClient_ClientOpts(t *testing.T) {
+	resetTest()
+	ctx := context.Background()
+	_ = os.Setenv("GCLOUD_AUTH_PLUGIN", "true")
+	_ = os.Setenv("GCLOUD_AUTH_ACCESS_TOKEN", "access-token")
+	oldFunc := newClient
+	defer func() { newClient = oldFunc }()
+	newClient = func(ctx context.Context, database string, opts ...option.ClientOption) (*sp.Client, error) {
+		assert.Equal(t, len(opts), 1)
+		return &sp.Client{}, nil
+	}
+	c, err := GetOrCreateClient(ctx, "testURI")
+	assert.NotNil(t, c)
+	assert.Nil(t, err)
+}
+
 func TestGetOrCreateClient_OnlyOnceViaSync(t *testing.T) {
 	resetTest()
 	ctx := context.Background()

--- a/accessors/clients/spanner/instanceadmin/spanner_instance_admin.go
+++ b/accessors/clients/spanner/instanceadmin/spanner_instance_admin.go
@@ -19,6 +19,7 @@ import (
 	"sync"
 
 	instance "cloud.google.com/go/spanner/admin/instance/apiv1"
+	"github.com/GoogleCloudPlatform/spanner-migration-tool/accessors/clients"
 )
 
 var once sync.Once
@@ -32,7 +33,8 @@ func GetOrCreateClient(ctx context.Context) (*instance.InstanceAdminClient, erro
 	var err error
 	if instanceAdminClient == nil {
 		once.Do(func() {
-			instanceAdminClient, err = newInstanceAdminClient(ctx)
+			clientOptions := clients.FetchSpannerClientOptions()
+			instanceAdminClient, err = newInstanceAdminClient(ctx, clientOptions...)
 		})
 		if err != nil {
 			return nil, fmt.Errorf("failed to create spanner instance admin client: %v", err)

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -150,8 +150,8 @@ func createDatabase(ctx context.Context, dbURI, targetDialect string, spannerAcc
 func validateSpannerAccessor(ctx context.Context, dbURI string) (spanneraccessor.SpannerAccessor, error) {
 	spannerAccessor, err := import_file.NewSpannerAccessor(ctx, dbURI)
 	if err != nil {
-		logger.Log.Error(fmt.Sprintf("Unable to instantiate spanner client %v", err))
-		return nil, fmt.Errorf("unable to instantiate spanner client %v", err)
+		logger.Log.Error(fmt.Sprintf("Unable to instantiate spanner client: %v", err))
+		return nil, fmt.Errorf("unable to instantiate spanner client: %v", err)
 	}
 
 	return spannerAccessor, nil

--- a/common/utils/utils_test.go
+++ b/common/utils/utils_test.go
@@ -1,0 +1,154 @@
+package utils
+
+import (
+	"context"
+	"testing"
+
+	sp "cloud.google.com/go/spanner"
+	database "cloud.google.com/go/spanner/admin/database/apiv1"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/api/option"
+)
+
+func TestNewSpannerClient(t *testing.T) {
+	ctx := context.Background()
+	db := "projects/p/instances/i/databases/d"
+
+	tests := []struct {
+		name                 string
+		spannerApiEndpoint   string
+		gcloudAuthPlugin     string
+		gcloudAuthToken      string
+		expectedOptionsCount int
+	}{
+		{
+			name:                 "No env vars set",
+			expectedOptionsCount: 0,
+		},
+		{
+			name:                 "Only SPANNER_API_ENDPOINT set",
+			spannerApiEndpoint:   "localhost:9010",
+			expectedOptionsCount: 1,
+		},
+		{
+			name:                 "Only GCLOUD_AUTH_PLUGIN set to true",
+			gcloudAuthPlugin:     "true",
+			gcloudAuthToken:      "test-token",
+			expectedOptionsCount: 1,
+		},
+		{
+			name:                 "Both SPANNER_API_ENDPOINT and GCLOUD_AUTH_PLUGIN set",
+			spannerApiEndpoint:   "localhost:9010",
+			gcloudAuthPlugin:     "true",
+			gcloudAuthToken:      "test-token",
+			expectedOptionsCount: 2,
+		},
+		{
+			name:                 "GCLOUD_AUTH_PLUGIN set to false",
+			gcloudAuthPlugin:     "false",
+			expectedOptionsCount: 0,
+		},
+		{
+			name:                 "SPANNER_API_ENDPOINT set and GCLOUD_AUTH_PLUGIN is false",
+			spannerApiEndpoint:   "localhost:9010",
+			gcloudAuthPlugin:     "false",
+			expectedOptionsCount: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			oldFunc := newClient
+			defer func() { newClient = oldFunc }()
+			if tt.spannerApiEndpoint != "" {
+				t.Setenv("SPANNER_API_ENDPOINT", tt.spannerApiEndpoint)
+			}
+			if tt.gcloudAuthPlugin != "" {
+				t.Setenv("GCLOUD_AUTH_PLUGIN", tt.gcloudAuthPlugin)
+			}
+			if tt.gcloudAuthToken != "" {
+				t.Setenv("GCLOUD_AUTH_ACCESS_TOKEN", tt.gcloudAuthToken)
+			}
+
+			newClient = func(ctx context.Context, database string, opts ...option.ClientOption) (*sp.Client, error) {
+				assert.Equal(t, db, database)
+				assert.Len(t, opts, tt.expectedOptionsCount)
+				return nil, nil
+			}
+
+			_, err := NewSpannerClient(ctx, db)
+			assert.NoError(t, err)
+		})
+	}
+}
+
+func TestNewDatabaseAdminClient(t *testing.T) {
+	ctx := context.Background()
+
+	origNewDatabaseAdminClientFunc := newDatabaseAdminClient
+	defer func() { newDatabaseAdminClient = origNewDatabaseAdminClientFunc }()
+
+	tests := []struct {
+		name                 string
+		spannerApiEndpoint   string
+		gcloudAuthPlugin     string
+		gcloudAuthToken      string
+		expectedOptionsCount int
+	}{
+		{
+			name:                 "No env vars set",
+			expectedOptionsCount: 0,
+		},
+		{
+			name:                 "Only SPANNER_API_ENDPOINT set",
+			spannerApiEndpoint:   "localhost:9010",
+			expectedOptionsCount: 1,
+		},
+		{
+			name:                 "Only GCLOUD_AUTH_PLUGIN set to true",
+			gcloudAuthPlugin:     "true",
+			gcloudAuthToken:      "test-token",
+			expectedOptionsCount: 1,
+		},
+		{
+			name:                 "Both SPANNER_API_ENDPOINT and GCLOUD_AUTH_PLUGIN set",
+			spannerApiEndpoint:   "localhost:9010",
+			gcloudAuthPlugin:     "true",
+			gcloudAuthToken:      "test-token",
+			expectedOptionsCount: 2,
+		},
+		{
+			name:                 "GCLOUD_AUTH_PLUGIN set to false",
+			gcloudAuthPlugin:     "false",
+			expectedOptionsCount: 0,
+		},
+		{
+			name:                 "SPANNER_API_ENDPOINT set and GCLOUD_AUTH_PLUGIN is false",
+			spannerApiEndpoint:   "localhost:9010",
+			gcloudAuthPlugin:     "false",
+			expectedOptionsCount: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.spannerApiEndpoint != "" {
+				t.Setenv("SPANNER_API_ENDPOINT", tt.spannerApiEndpoint)
+			}
+			if tt.gcloudAuthPlugin != "" {
+				t.Setenv("GCLOUD_AUTH_PLUGIN", tt.gcloudAuthPlugin)
+			}
+			if tt.gcloudAuthToken != "" {
+				t.Setenv("GCLOUD_AUTH_ACCESS_TOKEN", tt.gcloudAuthToken)
+			}
+
+			newDatabaseAdminClient = func(ctx context.Context, opts ...option.ClientOption) (*database.DatabaseAdminClient, error) {
+				assert.Len(t, opts, tt.expectedOptionsCount)
+				return nil, nil
+			}
+
+			_, err := NewDatabaseAdminClient(ctx)
+			assert.NoError(t, err)
+		})
+	}
+}

--- a/file_reader/gcs_file_reader.go
+++ b/file_reader/gcs_file_reader.go
@@ -4,6 +4,7 @@ import (
 	"cloud.google.com/go/storage"
 	"context"
 	"fmt"
+	"github.com/GoogleCloudPlatform/spanner-migration-tool/accessors/clients"
 	"github.com/GoogleCloudPlatform/spanner-migration-tool/logger"
 	"google.golang.org/api/option"
 	"io"
@@ -23,7 +24,8 @@ type GcsFileReaderImpl struct {
 
 func NewGcsFileReader(ctx context.Context, uri, host, path string) (*GcsFileReaderImpl, error) {
 	fmt.Printf("uri: %v, host: %v, path: %v\n", uri, host, path)
-	storageClient, err := GoogleStorageNewClient(ctx)
+	clientOptions := clients.FetchStorageClientOptions()
+	storageClient, err := GoogleStorageNewClient(ctx, clientOptions...)
 	if err != nil {
 		return nil, err
 	}

--- a/webv2/helpers/helpers.go
+++ b/webv2/helpers/helpers.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	database "cloud.google.com/go/spanner/admin/database/apiv1"
+	"github.com/GoogleCloudPlatform/spanner-migration-tool/accessors/clients"
 	spanneraccessor "github.com/GoogleCloudPlatform/spanner-migration-tool/accessors/spanner"
 	"github.com/GoogleCloudPlatform/spanner-migration-tool/common/constants"
 	adminpb "google.golang.org/genproto/googleapis/spanner/admin/database/v1"
@@ -108,7 +109,8 @@ func createDatabase(ctx context.Context, uri string, dbExists bool) error {
 	spInstance := matches[1]
 	dbName := matches[2]
 
-	adminClient, err := database.NewDatabaseAdminClient(ctx)
+	clientOptions := clients.FetchSpannerClientOptions()
+	adminClient, err := database.NewDatabaseAdminClient(ctx, clientOptions...)
 	if err != nil {
 		return err
 	}
@@ -178,7 +180,7 @@ func GetSourceDatabaseFromDriver(driver string) (string, error) {
 	case constants.ORACLE, constants.SQLSERVER:
 		return driver, nil
 	case constants.CASSANDRA:
-		return constants.CASSANDRA, nil	
+		return constants.CASSANDRA, nil
 	default:
 		return "", fmt.Errorf("unsupported driver type: %v", driver)
 	}


### PR DESCRIPTION
- Currently SMT only supports Application default login
- Recommendation from GCLOUD is to use access token. 
- This is enforced in there E2E test framework.
- This PR adds support to pass Auth token via environment variable.