### PR TITLE
added NUMERIC as an option as target datatype for BIGINT

### DIFF
--- a/sources/mysql/toddl.go
+++ b/sources/mysql/toddl.go
@@ -137,6 +137,8 @@ func toSpannerTypeInternal(srcType schema.Type, spType string) (ddl.Type, []inte
 		switch spType {
 		case ddl.String:
 			return ddl.Type{Name: ddl.String, Len: ddl.MaxLength}, []internal.SchemaIssue{internal.Widened}
+		case ddl.Numeric:
+			return ddl.Type{Name: ddl.Numeric}, []internal.SchemaIssue{internal.Widened}
 		default:
 			return ddl.Type{Name: ddl.Int64}, nil
 		}

--- a/sources/mysql/toddl_test.go
+++ b/sources/mysql/toddl_test.go
@@ -67,6 +67,10 @@ func TestToSpannerTypeInternal(t *testing.T) {
 	if errCheck == nil {
 		t.Errorf("Error in bigint to string conversion")
 	}
+	_, errCheck = toSpannerTypeInternal(schema.Type{"bigint", []int64{1, 2, 3}, []int64{1, 2, 3}}, "NUMERIC")
+	if errCheck == nil {
+		t.Errorf("Error in bigint to numeric conversion")
+	}
 	_, errCheck = toSpannerTypeInternal(schema.Type{"int", []int64{1, 2, 3}, []int64{1, 2, 3}}, "STRING")
 	if errCheck == nil {
 		t.Errorf("Error in int to string conversion")


### PR DESCRIPTION
Fixes b/368291549
Added option to convert BIGINT to NUMERIC. Will be helpful if one has BIGINT UNSIGNED column in source with values that donot fit in spanner INT64. 

- All Tests pass

- UI shows Numeric as an option
<img width="609" height="375" alt="Screenshot 2025-08-20 at 12 21 27 PM" src="https://github.com/user-attachments/assets/c17c68d1-5a03-47e6-8eef-99879ee0d622" />

- works as expected from CLI as well. (tested with schema-migration dry run)

