### PR TITLE
Bigint unsigned handling

### DIFF
--- a/internal/convert.go
+++ b/internal/convert.go
@@ -152,6 +152,7 @@ const (
 	CassandraUUID
 	CassandraTIMEUUID
 	CassandraMAP
+	PossibleOverflow
 )
 
 const (

--- a/internal/reports/report_helpers.go
+++ b/internal/reports/report_helpers.go
@@ -570,41 +570,6 @@ func getInterleaveDetail(conv *internal.Conv, tableId string, colId string, issu
 			}
 		}
 	}
-	// Search for potential parents even if there is no foreign key.
-	// This is for INTERLEAVE IN, where we don't need an FK.
-	// We check if the child's PK has a prefix that matches a potential parent's PK.
-	// We assume that the column names and types are the same in this case.
-	childPks := make([]ddl.IndexKey, len(table.PrimaryKeys))
-	copy(childPks, table.PrimaryKeys)
-	sort.Slice(childPks, func(i, j int) bool { return childPks[i].Order < childPks[j].Order })
-
-	if len(childPks) > 0 && childPks[0].ColId == colId {
-		for pTableId, pTable := range conv.SpSchema {
-			if pTableId == tableId {
-				continue
-			}
-			parentPks := make([]ddl.IndexKey, len(pTable.PrimaryKeys))
-			copy(parentPks, pTable.PrimaryKeys)
-			sort.Slice(parentPks, func(i, j int) bool { return parentPks[i].Order < parentPks[j].Order })
-
-			if len(parentPks) > 0 && len(childPks) > len(parentPks) {
-				isPrefix := true
-				for i, pPk := range parentPks {
-					cPk := childPks[i]
-					if table.ColDefs[cPk.ColId].Name != pTable.ColDefs[pPk.ColId].Name || table.ColDefs[cPk.ColId].T != pTable.ColDefs[pPk.ColId].T {
-						isPrefix = false
-						break
-					}
-				}
-
-				if isPrefix && len(parentPks) == 1 {
-					if issueType == internal.InterleavedOrder {
-						return pTable.Name, "", ""
-					}
-				}
-			}
-		}
-	}
 	return "", "", ""
 }
 
@@ -712,7 +677,6 @@ var IssueDB = map[internal.SchemaIssue]struct {
 	internal.CassandraUUID:                {Brief: "Cassandra UUIDs map to Spanner's BYTES(16). This generic type doesn't validate UUID versions.", Severity: warning, Category: "CASSANDRA_UUID_USES"},
 	internal.CassandraTIMEUUID:            {Brief: "Cassandra TimeUUIDs map to Spanner's BYTES(16). This generic type doesn't validate embedded timestamps.", Severity: warning, Category: "CASSANDRA_TIMEUUID_USES"},
 	internal.CassandraMAP:                 {Brief: "Cassandra MAP type maps to Spanner's JSON. Spanner does not validate internal JSON structure or types, unlike Cassandra's MAP.", Severity: warning, Category: "CASSANDRA_MAP_USES"},
-	internal.PossibleOverflow:             {Brief: "Possible overflow in Spanner. Source type does not entirely fit inside Spanner's type. Please check if the data fits within the target type's limits.", Severity: warning, Category: "POSSIBLE_OVERFLOW"},
 }
 
 type Severity int

--- a/internal/reports/report_helpers.go
+++ b/internal/reports/report_helpers.go
@@ -677,6 +677,7 @@ var IssueDB = map[internal.SchemaIssue]struct {
 	internal.CassandraUUID:                {Brief: "Cassandra UUIDs map to Spanner's BYTES(16). This generic type doesn't validate UUID versions.", Severity: warning, Category: "CASSANDRA_UUID_USES"},
 	internal.CassandraTIMEUUID:            {Brief: "Cassandra TimeUUIDs map to Spanner's BYTES(16). This generic type doesn't validate embedded timestamps.", Severity: warning, Category: "CASSANDRA_TIMEUUID_USES"},
 	internal.CassandraMAP:                 {Brief: "Cassandra MAP type maps to Spanner's JSON. Spanner does not validate internal JSON structure or types, unlike Cassandra's MAP.", Severity: warning, Category: "CASSANDRA_MAP_USES"},
+	internal.PossibleOverflow:             {Brief: "Possible overflow in Spanner. Source type does not entirely fit inside Spanner's type. Please check if the data fits within the target type's limits.", Severity: warning, Category: "POSSIBLE_OVERFLOW"},
 }
 
 type Severity int

--- a/sources/mysql/infoschema.go
+++ b/sources/mysql/infoschema.go
@@ -538,6 +538,14 @@ func toType(dataType string, columnType string, charLen sql.NullInt64, numericPr
 			return schema.Type{Name: dataType}
 		}
 		return schema.Type{Name: dataType, Mods: []int64{length}}
+	case dataType == "bigint" && len(columnType) > len("bigint") && strings.Contains(strings.ToUpper(columnType), "UNSIGNED"):
+		if numericPrecision.Valid && numericScale.Valid && numericScale.Int64 != 0 {
+			return schema.Type{Name: "bigint unsigned", Mods: []int64{numericPrecision.Int64, numericScale.Int64}}
+		} else if numericPrecision.Valid {
+			return schema.Type{Name: "bigint unsigned", Mods: []int64{numericPrecision.Int64}}
+		} else {
+			return schema.Type{Name: "bigint unsigned"}
+		}
 	case numericPrecision.Valid && numericScale.Valid && numericScale.Int64 != 0:
 		return schema.Type{Name: dataType, Mods: []int64{numericPrecision.Int64, numericScale.Int64}}
 	case numericPrecision.Valid:

--- a/sources/mysql/infoschema_test.go
+++ b/sources/mysql/infoschema_test.go
@@ -229,6 +229,7 @@ func TestProcessSchemaMYSQL(t *testing.T) {
 				{"tz", "timestamp", "timestamp", "YES", nil, nil, nil, nil, nil},
 				{"vc", "varchar", "varchar", "YES", nil, nil, nil, nil, nil},
 				{"vc6", "varchar", "varchar(6)", "YES", nil, 6, nil, nil, nil},
+				{"bu", "bigint", "bigint(20) unsigned", "YES", nil, nil, 20, 0, nil},
 			},
 		},
 		// db call to fetch index happens after fetching of column
@@ -302,7 +303,7 @@ func TestProcessSchemaMYSQL(t *testing.T) {
 			PrimaryKeys: []schema.Key{{ColId: "product_id", Desc: false, Order: 0}},
 			ForeignKeys: []schema.ForeignKey(nil),
 			Indexes:     []schema.Index(nil), Id: ""},
-		"test": schema.Table{Name: "test", Schema: "test", ColIds: []string{"id", "s", "txt", "b", "bs", "bl", "c", "c8", "d", "dec", "f8", "f4", "i8", "i4", "i2", "si", "ts", "tz", "vc", "vc6"}, ColDefs: map[string]schema.Column{
+		"test": schema.Table{Name: "test", Schema: "test", ColIds: []string{"id", "s", "txt", "b", "bs", "bl", "c", "c8", "d", "dec", "f8", "f4", "i8", "i4", "i2", "si", "ts", "tz", "vc", "vc6", "bu"}, ColDefs: map[string]schema.Column{
 			"b":   schema.Column{Name: "b", Type: schema.Type{Name: "boolean", Mods: []int64(nil), ArrayBounds: []int64(nil)}, NotNull: false, Ignored: schema.Ignored{Check: false, Identity: false, Default: false, Exclusion: false, ForeignKey: false, AutoIncrement: false}, Id: ""},
 			"bl":  schema.Column{Name: "bl", Type: schema.Type{Name: "blob", Mods: []int64(nil), ArrayBounds: []int64(nil)}, NotNull: false, Ignored: schema.Ignored{Check: false, Identity: false, Default: false, Exclusion: false, ForeignKey: false, AutoIncrement: false}, Id: ""},
 			"bs":  schema.Column{Name: "bs", Type: schema.Type{Name: "bigint", Mods: []int64{64}, ArrayBounds: []int64(nil)}, NotNull: true, Ignored: schema.Ignored{Check: false, Identity: false, Default: true, Exclusion: false, ForeignKey: false, AutoIncrement: false}, Id: "", DefaultValue: ddl.DefaultValue{IsPresent: true, Value: ddl.Expression{ExpressionId: "e27", Statement: "nextval('test11_bs_seq'::regclass)"}}},
@@ -322,7 +323,8 @@ func TestProcessSchemaMYSQL(t *testing.T) {
 			"txt": schema.Column{Name: "txt", Type: schema.Type{Name: "text", Mods: []int64(nil), ArrayBounds: []int64(nil)}, NotNull: true, Ignored: schema.Ignored{Check: false, Identity: false, Default: false, Exclusion: false, ForeignKey: false, AutoIncrement: false}, Id: ""},
 			"tz":  schema.Column{Name: "tz", Type: schema.Type{Name: "timestamp", Mods: []int64(nil), ArrayBounds: []int64(nil)}, NotNull: false, Ignored: schema.Ignored{Check: false, Identity: false, Default: false, Exclusion: false, ForeignKey: false, AutoIncrement: false}, Id: ""},
 			"vc":  schema.Column{Name: "vc", Type: schema.Type{Name: "varchar", Mods: []int64(nil), ArrayBounds: []int64(nil)}, NotNull: false, Ignored: schema.Ignored{Check: false, Identity: false, Default: false, Exclusion: false, ForeignKey: false, AutoIncrement: false}, Id: ""},
-			"vc6": schema.Column{Name: "vc6", Type: schema.Type{Name: "varchar", Mods: []int64{6}, ArrayBounds: []int64(nil)}, NotNull: false, Ignored: schema.Ignored{Check: false, Identity: false, Default: false, Exclusion: false, ForeignKey: false, AutoIncrement: false}, Id: ""}},
+			"vc6": schema.Column{Name: "vc6", Type: schema.Type{Name: "varchar", Mods: []int64{6}, ArrayBounds: []int64(nil)}, NotNull: false, Ignored: schema.Ignored{Check: false, Identity: false, Default: false, Exclusion: false, ForeignKey: false, AutoIncrement: false}, Id: ""},
+			"bu":  schema.Column{Name: "bu", Type: schema.Type{Name: "bigint unsigned", Mods: []int64{20}, ArrayBounds: []int64(nil)}, NotNull: false, Ignored: schema.Ignored{Check: false, Identity: false, Default: false, Exclusion: false, ForeignKey: false, AutoIncrement: false}, Id: ""}},
 			PrimaryKeys: []schema.Key{schema.Key{ColId: "id", Desc: false, Order: 0}},
 			ForeignKeys: []schema.ForeignKey{schema.ForeignKey{Name: "fk_test4", ColIds: []string{"id", "txt"}, ReferTableId: "test_ref", ReferColumnIds: []string{"ref_id", "ref_txt"}, OnUpdate: constants.FK_RESTRICT, OnDelete: constants.FK_CASCADE, Id: ""}},
 			Indexes:     []schema.Index(nil), Id: ""},
@@ -562,7 +564,7 @@ func TestProcessData_MultiCol(t *testing.T) {
 	}
 	internal.AssertSpSchema(conv, t, expectedSchema, stripSchemaComments(conv.SpSchema))
 	columnLevelIssues := map[string][]internal.SchemaIssue{
-		"c56": []internal.SchemaIssue{
+		"c57": []internal.SchemaIssue{
 			2,
 		},
 	}

--- a/sources/mysql/mysqldump.go
+++ b/sources/mysql/mysqldump.go
@@ -619,9 +619,9 @@ func getTypeModsAndID(conv *internal.Conv, columnType string) (string, []int64) 
 		id = strings.TrimSuffix(columnType, " BINARY")
 	}
 	// Bigint unsigned comes as bigint(20) UNSIGNED in columnType and is treated as bigint in id.
-	// An extra check is added to respect to the unsigned nature. 
+	// An extra check is added to respect the unsigned nature.
 	if id == "bigint" && strings.Contains(strings.ToUpper(columnType), "UNSIGNED") {
-		id = strings.Join([]string{id, "unsigned"}, " ")
+		id = "bigint unsigned"
 	}
 	return id, mods
 }

--- a/sources/mysql/mysqldump.go
+++ b/sources/mysql/mysqldump.go
@@ -618,6 +618,11 @@ func getTypeModsAndID(conv *internal.Conv, columnType string) (string, []int64) 
 	if strings.Contains(id, " ") {
 		id = strings.TrimSuffix(columnType, " BINARY")
 	}
+	// Bigint unsigned comes as bigint(20) UNSIGNED in columnType and is treated as bigint in id.
+	// An extra check is added to respect to the unsigned nature. 
+	if id == "bigint" && strings.Contains(strings.ToUpper(columnType), "UNSIGNED") {
+		id = strings.Join([]string{id, "unsigned"}, " ")
+	}
 	return id, mods
 }
 

--- a/sources/mysql/mysqldump_test.go
+++ b/sources/mysql/mysqldump_test.go
@@ -63,6 +63,7 @@ func TestProcessMySQLDump_Scalar(t *testing.T) {
 		{"bit(1)", ddl.Type{Name: ddl.Bool}},
 		{"bit(5)", ddl.Type{Name: ddl.Bytes, Len: ddl.MaxLength}},
 		{"smallint", ddl.Type{Name: ddl.Int64}},
+		{"bigint unsigned", ddl.Type{Name: ddl.Int64}},
 		{"text", ddl.Type{Name: ddl.String, Len: ddl.MaxLength}},
 		{"tinytext", ddl.Type{Name: ddl.String, Len: ddl.MaxLength}},
 		{"mediumtext", ddl.Type{Name: ddl.String, Len: ddl.MaxLength}},
@@ -122,16 +123,17 @@ func TestProcessMySQLDump_MultiCol(t *testing.T) {
 	}{
 		{
 			name: "Shopping cart",
-			input: "CREATE TABLE cart (productid text, userid text, quantity bigint);\n" +
+			input: "CREATE TABLE cart (productid text, userid text, quantity bigint, price bigint unsigned);\n" +
 				"ALTER TABLE cart ADD CONSTRAINT cart_pkey PRIMARY KEY (productid, userid);\n",
 			expectedSchema: map[string]ddl.CreateTable{
 				"cart": {
 					Name:   "cart",
-					ColIds: []string{"productid", "userid", "quantity"},
+					ColIds: []string{"productid", "userid", "quantity", "price"},
 					ColDefs: map[string]ddl.ColumnDef{
 						"productid": {Name: "productid", T: ddl.Type{Name: ddl.String, Len: ddl.MaxLength}, NotNull: true},
 						"userid":    {Name: "userid", T: ddl.Type{Name: ddl.String, Len: ddl.MaxLength}, NotNull: true},
 						"quantity":  {Name: "quantity", T: ddl.Type{Name: ddl.Int64}},
+						"price":    {Name: "price", T: ddl.Type{Name: ddl.Int64}},
 					},
 					PrimaryKeys: []ddl.IndexKey{{ColId: "productid", Order: 1}, {ColId: "userid", Order: 2}}}},
 		},

--- a/sources/mysql/toddl.go
+++ b/sources/mysql/toddl.go
@@ -133,13 +133,16 @@ func toSpannerTypeInternal(srcType schema.Type, spType string) (ddl.Type, []inte
 			// capabilities between MySQL and Spanner NUMERIC.
 			return ddl.Type{Name: ddl.Numeric}, nil
 		}
-	case "bigint":
+ 	case "bigint", "bigint unsigned":
 		switch spType {
 		case ddl.String:
 			return ddl.Type{Name: ddl.String, Len: ddl.MaxLength}, []internal.SchemaIssue{internal.Widened}
 		case ddl.Numeric:
 			return ddl.Type{Name: ddl.Numeric}, []internal.SchemaIssue{internal.Widened}
 		default:
+			if srcType.Name == "bigint unsigned" {
+				return ddl.Type{Name: ddl.Int64}, []internal.SchemaIssue{internal.PossibleOverflow}
+			}
 			return ddl.Type{Name: ddl.Int64}, nil
 		}
 	case "smallint", "mediumint", "integer", "int":

--- a/sources/mysql/toddl.go
+++ b/sources/mysql/toddl.go
@@ -133,17 +133,23 @@ func toSpannerTypeInternal(srcType schema.Type, spType string) (ddl.Type, []inte
 			// capabilities between MySQL and Spanner NUMERIC.
 			return ddl.Type{Name: ddl.Numeric}, nil
 		}
- 	case "bigint", "bigint unsigned":
+ 	case "bigint":
 		switch spType {
 		case ddl.String:
 			return ddl.Type{Name: ddl.String, Len: ddl.MaxLength}, []internal.SchemaIssue{internal.Widened}
 		case ddl.Numeric:
 			return ddl.Type{Name: ddl.Numeric}, []internal.SchemaIssue{internal.Widened}
 		default:
-			if srcType.Name == "bigint unsigned" {
-				return ddl.Type{Name: ddl.Int64}, []internal.SchemaIssue{internal.PossibleOverflow}
-			}
 			return ddl.Type{Name: ddl.Int64}, nil
+		}
+	case "bigint unsigned":
+		switch spType {
+		case ddl.String:
+			return ddl.Type{Name: ddl.String, Len: ddl.MaxLength}, []internal.SchemaIssue{internal.Widened}
+		case ddl.Numeric:
+			return ddl.Type{Name: ddl.Numeric}, []internal.SchemaIssue{internal.Widened}
+		default:
+			return ddl.Type{Name: ddl.Int64}, []internal.SchemaIssue{internal.PossibleOverflow}
 		}
 	case "smallint", "mediumint", "integer", "int":
 		switch spType {

--- a/sources/mysql/toddl.go
+++ b/sources/mysql/toddl.go
@@ -137,6 +137,8 @@ func toSpannerTypeInternal(srcType schema.Type, spType string) (ddl.Type, []inte
 		switch spType {
 		case ddl.String:
 			return ddl.Type{Name: ddl.String, Len: ddl.MaxLength}, []internal.SchemaIssue{internal.Widened}
+		case ddl.Numeric:
+			return ddl.Type{Name: ddl.Numeric}, []internal.SchemaIssue{internal.Widened}
 		default:
 			return ddl.Type{Name: ddl.Int64}, nil
 		}

--- a/sources/mysql/toddl_test.go
+++ b/sources/mysql/toddl_test.go
@@ -67,6 +67,10 @@ func TestToSpannerTypeInternal(t *testing.T) {
 	if errCheck == nil {
 		t.Errorf("Error in bigint to string conversion")
 	}
+	_, errCheck = toSpannerTypeInternal(schema.Type{"bigint", []int64{1, 2, 3}, []int64{1, 2, 3}}, "NUMERIC")
+	if errCheck == nil {
+		t.Errorf("Error in bigint to numeric conversion")
+	}
 	_, errCheck = toSpannerTypeInternal(schema.Type{"int", []int64{1, 2, 3}, []int64{1, 2, 3}}, "STRING")
 	if errCheck == nil {
 		t.Errorf("Error in int to string conversion")


### PR DESCRIPTION
Fixes b/439992639

> Added identification of `bigint unsigned` as a different datatype from `bigint` (both from infoschema and dump file)for different handling
> Added an generalized warning for possible overflow
> raises possible overflow warning when converting `bigint unsigned` to `int64`

- all tests pass
- changes work in UI
<img width="1723" height="739" alt="Screenshot 2025-08-25 at 9 59 38 AM" src="https://github.com/user-attachments/assets/30ae5dbf-5807-4aaa-bfff-9d9452d4bd4d" />

<img width="1723" height="739" alt="Screenshot 2025-08-25 at 9 56 55 AM" src="https://github.com/user-attachments/assets/b4042632-132a-4998-bbf3-56f4ad0b5d9b" />
