### PR TITLE
chore: Fix CVE-2025-61727

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/GoogleCloudPlatform/spanner-migration-tool
 
-go 1.24.0
-
-toolchain go1.24.8
+go 1.24.11
 
 require (
 	cloud.google.com/go v0.120.0


### PR DESCRIPTION
Upgrade Go to 1.24.11 to address CVE-2025-61727