### PR TITLE
Update Golang to 1.25.10

### DIFF
--- a/.github/workflows/integration-tests-against-omni.yaml
+++ b/.github/workflows/integration-tests-against-omni.yaml
@@ -151,7 +151,7 @@ jobs:
 
       - uses: actions/setup-go@v2
         with:
-          go-version: "1.25.9"
+          go-version: "1.25.10"
       - run: go version
       - run: go build
       - name: Wait for Spanner Omni to start

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v2
         with:
-          go-version: "1.25.9"
+          go-version: "1.25.10"
       - name: Set up Node.js
         uses: actions/setup-node@v2
         with:

--- a/docs/install.md
+++ b/docs/install.md
@@ -91,7 +91,7 @@ Detailed instructions on how to install a new component in gCloud can be found [
 Building from source is only supported for MacOS and Linux based platforms.
 
 1. Install Go ([download](https://golang.org/doc/install)) on your development machine if it is not already installed, configure the [GOPATH](https://pkg.go.dev/cmd/go@master#hdr-GOPATH_environment_variable) environment variable if it is not already configured, and [test your installation](https://golang.org/doc/install#testing). <br/>
-    Required go version: 1.25.9+
+    Required go version: 1.25.10+
 2. Install nodejs ([download](https://nodejs.org/en/download)). <br/>
     Required node version: v18.20.6+
 3. Install angular-cli ([instructions](https://angular.dev/tools/cli/setup-local#install-the-angular-cli))

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/spanner-migration-tool
 
-go 1.25.9
+go 1.25.10
 
 require (
 	cloud.google.com/go v0.123.0


### PR DESCRIPTION
Updates Golang to `1.25.10` to address vulnerabilities.