### PR TITLE
Add support for TLS/mTLS connections in MySQL, PostgreSQL and Cassandra

### DIFF
--- a/accessors/cassandra/cassandra_accessor.go
+++ b/accessors/cassandra/cassandra_accessor.go
@@ -41,6 +41,10 @@ func NewCassandraAccessor(sourceProfile profiles.SourceProfile) (*CassandraAcces
 		cfg.DataCenter,
 		cfg.User,
 		cfg.Pwd,
+		cfg.Sslmode,
+		cfg.Sslrootcert,
+		cfg.Sslcert,
+		cfg.Sslkey,
 	)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create Cassandra client: %w", err)

--- a/accessors/cassandra/cassandra_accessor_test.go
+++ b/accessors/cassandra/cassandra_accessor_test.go
@@ -46,7 +46,7 @@ func TestNewCassandraAccessor(t *testing.T) {
 
 		mockClient.On("KeyspaceMetadata", "test_keyspace").Return(mockMetadata, nil).Once()
 
-		GetOrCreateClient = func(contactPoints []string, port int, keyspace, datacenter, user, password string) (cc.CassandraClusterInterface, error) {
+		GetOrCreateClient = func(contactPoints []string, port int, keyspace, datacenter, user, password string, sslmode, sslrootcert, sslcert, sslkey string) (cc.CassandraClusterInterface, error) {
 			assert.Equal(t, []string{"127.0.0.1"}, contactPoints)
 			assert.Equal(t, 9042, port)
 			assert.Equal(t, "test_keyspace", keyspace)
@@ -68,7 +68,7 @@ func TestNewCassandraAccessor(t *testing.T) {
 
 	t.Run("Failure to create client", func(t *testing.T) {
 		expectedErr := errors.New("client creation failed")
-		GetOrCreateClient = func(contactPoints []string, port int, keyspace, datacenter, user, password string) (cc.CassandraClusterInterface, error) {
+		GetOrCreateClient = func(contactPoints []string, port int, keyspace, datacenter, user, password string, sslmode, sslrootcert, sslcert, sslkey string) (cc.CassandraClusterInterface, error) {
 			return nil, expectedErr
 		}
 
@@ -88,7 +88,7 @@ func TestNewCassandraAccessor(t *testing.T) {
 		mockClient.On("KeyspaceMetadata", "test_keyspace").Return(nil, expectedErr).Once()
 		mockClient.On("Close").Return().Once()
 
-		GetOrCreateClient = func(contactPoints []string, port int, keyspace, datacenter, user, password string) (cc.CassandraClusterInterface, error) {
+		GetOrCreateClient = func(contactPoints []string, port int, keyspace, datacenter, user, password string, sslmode, sslrootcert, sslcert, sslkey string) (cc.CassandraClusterInterface, error) {
 			return mockClient, nil
 		}
 

--- a/accessors/clients/cassandra/cassandra_client.go
+++ b/accessors/clients/cassandra/cassandra_client.go
@@ -36,7 +36,7 @@ var createSessionFromCluster = func(c *gocql.ClusterConfig) (GocqlSessionInterfa
 	return NewGocqlSessionImpl(session), nil
 }
 
-func GetOrCreateCassandraClusterClient(contactPoints []string, port int, keyspace, datacenter, user, password string) (CassandraClusterInterface, error) {
+func GetOrCreateCassandraClusterClient(contactPoints []string, port int, keyspace, datacenter, user, password string, sslmode, sslrootcert, sslcert, sslkey string) (CassandraClusterInterface, error) {
 	clusterConfigMux.Lock()
 	defer clusterConfigMux.Unlock()
 	
@@ -53,6 +53,14 @@ func GetOrCreateCassandraClusterClient(contactPoints []string, port int, keyspac
 	}
 	if datacenter != "" {
 		clusterCfg.PoolConfig.HostSelectionPolicy = gocql.DCAwareRoundRobinPolicy(datacenter)
+	}
+	if sslmode != "" && sslmode != "disable" {
+		clusterCfg.SslOpts = &gocql.SslOptions{
+			CaPath:                 sslrootcert,
+			CertPath:               sslcert,
+			KeyPath:                sslkey,
+			EnableHostVerification: sslmode == "verify-full",
+		}
 	}
 	globalClusterConfig = clusterCfg
 

--- a/accessors/clients/cassandra/cassandra_client_test.go
+++ b/accessors/clients/cassandra/cassandra_client_test.go
@@ -53,7 +53,7 @@ func TestGetOrCreateCassandraClusterClient(t *testing.T) {
 			return mockSession, nil
 		}
 
-		client, err := GetOrCreateCassandraClusterClient([]string{"127.0.0.1"}, 0, "test_keyspace", "", "", "")
+		client, err := GetOrCreateCassandraClusterClient([]string{"127.0.0.1"}, 0, "test_keyspace", "", "", "", "", "", "", "")
 
 		assert.NoError(t, err)
 		assert.NotNil(t, client)
@@ -80,7 +80,7 @@ func TestGetOrCreateCassandraClusterClient(t *testing.T) {
 			return mockSession, nil
 		}
 
-		client, err := GetOrCreateCassandraClusterClient([]string{"127.0.0.1"}, 9042, "ks", "dc1", "user", "pass")
+		client, err := GetOrCreateCassandraClusterClient([]string{"127.0.0.1"}, 9042, "ks", "dc1", "user", "pass", "", "", "", "")
 
 		assert.NoError(t, err)
 		assert.NotNil(t, client)
@@ -98,7 +98,7 @@ func TestGetOrCreateCassandraClusterClient(t *testing.T) {
 			return nil, expectedErr
 		}
 
-		client, err := GetOrCreateCassandraClusterClient([]string{"127.0.0.1"}, 9042, "ks", "", "", "")
+		client, err := GetOrCreateCassandraClusterClient([]string{"127.0.0.1"}, 9042, "ks", "", "", "", "", "", "", "")
 
 		assert.Nil(t, client)
 		assert.Error(t, err)
@@ -123,13 +123,37 @@ func TestGetOrCreateCassandraClusterClient(t *testing.T) {
 		for i := 0; i < numGoroutines; i++ {
 			go func(i int) {
 				defer wg.Done()
-				_, err := GetOrCreateCassandraClusterClient([]string{"127.0.0.1"}, 9042, fmt.Sprintf("keyspace%d", i), "", "", "")
+				_, err := GetOrCreateCassandraClusterClient([]string{"127.0.0.1"}, 9042, fmt.Sprintf("keyspace%d", i), "", "", "", "", "", "", "")
 				assert.NoError(t, err)
 			}(i)
 		}
 
 		wg.Wait()
 		assert.NotNil(t, globalClusterConfig, "globalClusterConfig should be set after concurrent calls")
+	})
+	t.Run("Success with SSL/TLS config", func(t *testing.T) {
+		resetGlobals()
+		var capturedClusterConfig *gocql.ClusterConfig
+
+		newCluster = func(contactPoints ...string) *gocql.ClusterConfig {
+			cfg := gocql.NewCluster(contactPoints...)
+			capturedClusterConfig = cfg
+			return cfg
+		}
+		mockSession := &MockGocqlSession{}
+		createSessionFromCluster = func(c *gocql.ClusterConfig) (GocqlSessionInterface, error) {
+			return mockSession, nil
+		}
+
+		client, err := GetOrCreateCassandraClusterClient([]string{"127.0.0.1"}, 9042, "ks", "dc1", "user", "pass", "verify-full", "ca.pem", "cert.pem", "key.pem")
+
+		assert.NoError(t, err)
+		assert.NotNil(t, client)
+		assert.NotNil(t, capturedClusterConfig.SslOpts)
+		assert.Equal(t, "ca.pem", capturedClusterConfig.SslOpts.CaPath)
+		assert.Equal(t, "cert.pem", capturedClusterConfig.SslOpts.CertPath)
+		assert.Equal(t, "key.pem", capturedClusterConfig.SslOpts.KeyPath)
+		assert.True(t, capturedClusterConfig.SslOpts.EnableHostVerification)
 	})
 }
 
@@ -142,6 +166,6 @@ func TestCreateSessionFromCluster(t *testing.T) {
 	}
 	t.Cleanup(func() { newCluster = originalNewCluster })
 
-	_, _ = GetOrCreateCassandraClusterClient([]string{"127.0.0.1"}, 9042, "keyspace", "dc", "user", "pass")
+	_, _ = GetOrCreateCassandraClusterClient([]string{"127.0.0.1"}, 9042, "keyspace", "dc", "user", "pass", "", "", "", "")
 	assert.NotNil(t, globalClusterConfig)
 }

--- a/profiles/common.go
+++ b/profiles/common.go
@@ -15,13 +15,17 @@
 package profiles
 
 import (
+	"crypto/tls"
+	"crypto/x509"
 	"encoding/csv"
 	"fmt"
 	"os"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/GoogleCloudPlatform/spanner-migration-tool/common/utils"
+	mysqldriver "github.com/go-sql-driver/mysql"
 	go_ora "github.com/sijms/go-ora/v2"
 	"github.com/GoogleCloudPlatform/spanner-migration-tool/logger"
 )
@@ -87,16 +91,65 @@ func ParseList(s string) ([]string, error) {
 	return records[0], nil
 }
 
+func registerMySQLTLSConfig(sslrootcert, sslcert, sslkey, sslmode string) (string, error) {
+	tlsConfig := &tls.Config{}
+
+	if sslrootcert != "" {
+		rootCertPool := x509.NewCertPool()
+		pem, err := os.ReadFile(sslrootcert)
+		if err != nil {
+			return "", fmt.Errorf("failed to read root CA cert: %w", err)
+		}
+		if ok := rootCertPool.AppendCertsFromPEM(pem); !ok {
+			return "", fmt.Errorf("failed to append root CA cert")
+		}
+		tlsConfig.RootCAs = rootCertPool
+	}
+
+	if sslcert != "" && sslkey != "" {
+		certs, err := tls.LoadX509KeyPair(sslcert, sslkey)
+		if err != nil {
+			return "", fmt.Errorf("failed to load client cert/key: %w", err)
+		}
+		tlsConfig.Certificates = []tls.Certificate{certs}
+	}
+
+	if sslmode == "verify-ca" {
+		tlsConfig.InsecureSkipVerify = true
+		tlsConfig.VerifyConnection = func(cs tls.ConnectionState) error {
+			opts := x509.VerifyOptions{
+				Roots:         tlsConfig.RootCAs,
+				CurrentTime:   time.Now(),
+				Intermediates: x509.NewCertPool(),
+			}
+			for _, cert := range cs.PeerCertificates[1:] {
+				opts.Intermediates.AddCert(cert)
+			}
+			_, err := cs.PeerCertificates[0].Verify(opts)
+			return err
+		}
+	} else if sslmode == "skip-verify" {
+		tlsConfig.InsecureSkipVerify = true
+	}
+
+	configName := fmt.Sprintf("custom_%d", time.Now().UnixNano())
+	err := mysqldriver.RegisterTLSConfig(configName, tlsConfig)
+	if err != nil {
+		return "", err
+	}
+	return configName, nil
+}
+
 func GetSQLConnectionStr(sourceProfile SourceProfile) string {
 	sqlConnectionStr := ""
 	if sourceProfile.Ty == SourceProfileTypeConnection {
 		switch sourceProfile.Conn.Ty {
 		case SourceProfileConnectionTypeMySQL:
 			connParams := sourceProfile.Conn.Mysql
-			return getMYSQLConnectionStr(connParams.Host, connParams.Port, connParams.User, connParams.Pwd, connParams.Db)
+			return getMYSQLConnectionStr(connParams.Host, connParams.Port, connParams.User, connParams.Pwd, connParams.Db, connParams.Sslmode, connParams.Sslrootcert, connParams.Sslcert, connParams.Sslkey)
 		case SourceProfileConnectionTypePostgreSQL:
 			connParams := sourceProfile.Conn.Pg
-			return getPGSQLConnectionStr(connParams.Host, connParams.Port, connParams.User, connParams.Pwd, connParams.Db)
+			return getPGSQLConnectionStr(connParams.Host, connParams.Port, connParams.User, connParams.Pwd, connParams.Db, connParams.Sslmode, connParams.Sslrootcert, connParams.Sslcert, connParams.Sslkey)
 		case SourceProfileConnectionTypeSqlServer:
 			connParams := sourceProfile.Conn.SqlServer
 			return getSQLSERVERConnectionStr(connParams.Host, connParams.Port, connParams.User, connParams.Pwd, connParams.Db)
@@ -122,11 +175,26 @@ func GeneratePGSQLConnectionStr() (string, error) {
 		getInfo := utils.GetUtilInfoImpl{}
 		password = getInfo.GetPassword()
 	}
-	return getPGSQLConnectionStr(server, port, user, password, dbName), nil
+	return getPGSQLConnectionStr(server, port, user, password, dbName, os.Getenv("PGSSLMODE"), os.Getenv("PGSSLROOTCERT"), os.Getenv("PGSSLCERT"), os.Getenv("PGSSLKEY")), nil
 }
 
-func getPGSQLConnectionStr(server, port, user, password, dbName string) string {
-	return fmt.Sprintf("host=%s port=%s user=%s password=%s dbname=%s sslmode=disable", server, port, user, password, dbName)
+func getPGSQLConnectionStr(server, port, user, password, dbName string, sslmode, sslrootcert, sslcert, sslkey string) string {
+	str := fmt.Sprintf("host=%s port=%s user=%s password=%s dbname=%s", server, port, user, password, dbName)
+	if sslmode != "" {
+		str = fmt.Sprintf("%s sslmode=%s", str, sslmode)
+	} else {
+		str = fmt.Sprintf("%s sslmode=disable", str)
+	}
+	if sslrootcert != "" {
+		str = fmt.Sprintf("%s sslrootcert=%s", str, sslrootcert)
+	}
+	if sslcert != "" {
+		str = fmt.Sprintf("%s sslcert=%s", str, sslcert)
+	}
+	if sslkey != "" {
+		str = fmt.Sprintf("%s sslkey=%s", str, sslkey)
+	}
+	return str
 }
 
 func GenerateMYSQLConnectionStr() (string, error) {
@@ -143,11 +211,34 @@ func GenerateMYSQLConnectionStr() (string, error) {
 		getInfo := utils.GetUtilInfoImpl{}
 		password = getInfo.GetPassword()
 	}
-	return getMYSQLConnectionStr(server, port, user, password, dbName), nil
+	return getMYSQLConnectionStr(server, port, user, password, dbName, os.Getenv("MYSQL_SSL_MODE"), os.Getenv("MYSQL_SSL_ROOT_CERT"), os.Getenv("MYSQL_SSL_CERT"), os.Getenv("MYSQL_SSL_KEY")), nil
 }
 
-func getMYSQLConnectionStr(server, port, user, password, dbName string) string {
-	return fmt.Sprintf("%s:%s@tcp(%s:%s)/%s", user, password, server, port, dbName)
+func getMYSQLConnectionStr(server, port, user, password, dbName string, sslmode, sslrootcert, sslcert, sslkey string) string {
+	base := fmt.Sprintf("%s:%s@tcp(%s:%s)/%s", user, password, server, port, dbName)
+	tlsParam := ""
+	if sslrootcert != "" || sslcert != "" || sslkey != "" {
+		configName, err := registerMySQLTLSConfig(sslrootcert, sslcert, sslkey, sslmode)
+		if err == nil {
+			tlsParam = configName
+		}
+	} else if sslmode != "" {
+		switch sslmode {
+		case "disable":
+			tlsParam = "false"
+		case "skip-verify":
+			tlsParam = "skip-verify"
+		case "require":
+			tlsParam = "true"
+		default:
+			tlsParam = "preferred"
+		}
+	}
+
+	if tlsParam != "" {
+		return fmt.Sprintf("%s?tls=%s", base, tlsParam)
+	}
+	return base
 }
 
 func getSQLSERVERConnectionStr(server, port, user, password, dbName string) string {

--- a/profiles/common_test.go
+++ b/profiles/common_test.go
@@ -15,7 +15,17 @@
 package profiles
 
 import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -124,6 +134,30 @@ func TestGetSQLConnectionStr(t *testing.T) {
 	user := "user"
 	pwd := "password"
 	db := "database"
+
+	// Generate a valid dummy CA certificate PEM
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	assert.NoError(t, err)
+	template := x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject: pkix.Name{
+			Organization: []string{"Dummy CA"},
+		},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	derBytes, err := x509.CreateCertificate(rand.Reader, &template, &template, &priv.PublicKey, priv)
+	assert.NoError(t, err)
+	certPem := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: derBytes})
+
+	tmpDir := t.TempDir()
+	caFile := filepath.Join(tmpDir, "ca.pem")
+	err = os.WriteFile(caFile, certPem, 0644)
+	assert.NoError(t, err)
+
 	testCases := []struct {
 		name                   string
 		inputSourceProfileConn SourceProfileConnection
@@ -135,9 +169,24 @@ func TestGetSQLConnectionStr(t *testing.T) {
 			expectedOutput:         "user:password@tcp(0.0.0.0:3306)/database",
 		},
 		{
+			name:                   "source profile connection type mysql with sslmode require",
+			inputSourceProfileConn: SourceProfileConnection{Ty: SourceProfileConnectionTypeMySQL, Mysql: SourceProfileConnectionMySQL{Host: host, Port: port, User: user, Pwd: pwd, Db: db, Sslmode: "require"}},
+			expectedOutput:         "user:password@tcp(0.0.0.0:3306)/database?tls=true",
+		},
+		{
+			name:                   "source profile connection type mysql with custom certs",
+			inputSourceProfileConn: SourceProfileConnection{Ty: SourceProfileConnectionTypeMySQL, Mysql: SourceProfileConnectionMySQL{Host: host, Port: port, User: user, Pwd: pwd, Db: db, Sslmode: "verify-ca", Sslrootcert: caFile}},
+			expectedOutput:         "user:password@tcp(0.0.0.0:3306)/database?tls=custom_",
+		},
+		{
 			name:                   "source profile connection type postgres",
 			inputSourceProfileConn: SourceProfileConnection{Ty: SourceProfileConnectionTypePostgreSQL, Pg: SourceProfileConnectionPostgreSQL{Host: host, Port: port, User: user, Pwd: pwd, Db: db}},
 			expectedOutput:         "host=0.0.0.0 port=3306 user=user password=password dbname=database sslmode=disable",
+		},
+		{
+			name:                   "source profile connection type postgres with TLS verify-full",
+			inputSourceProfileConn: SourceProfileConnection{Ty: SourceProfileConnectionTypePostgreSQL, Pg: SourceProfileConnectionPostgreSQL{Host: host, Port: port, User: user, Pwd: pwd, Db: db, Sslmode: "verify-full", Sslrootcert: "ca.pem", Sslcert: "cert.pem", Sslkey: "key.pem"}},
+			expectedOutput:         "host=0.0.0.0 port=3306 user=user password=password dbname=database sslmode=verify-full sslrootcert=ca.pem sslcert=cert.pem sslkey=key.pem",
 		},
 		{
 			name:                   "source profile connection type sql server",
@@ -153,7 +202,11 @@ func TestGetSQLConnectionStr(t *testing.T) {
 
 	for _, tc := range testCases {
 		res := GetSQLConnectionStr(SourceProfile{Ty: SourceProfileType(SourceProfileTypeConnection), Conn: tc.inputSourceProfileConn})
-		assert.Equal(t, tc.expectedOutput, res, tc.name)
+		if tc.name == "source profile connection type mysql with custom certs" {
+			assert.Contains(t, res, tc.expectedOutput)
+		} else {
+			assert.Equal(t, tc.expectedOutput, res, tc.name)
+		}
 	}
 }
 

--- a/profiles/source_profile.go
+++ b/profiles/source_profile.go
@@ -153,6 +153,10 @@ type SourceProfileConnectionMySQL struct {
 	User            string // Same as MYSQLUSER environment variable
 	Db              string // Same as MYSQLDATABASE environment variable
 	Pwd             string // Same as MYSQLPWD environment variable
+	Sslmode         string
+	Sslrootcert     string
+	Sslcert         string
+	Sslkey          string
 }
 
 func (spd *SourceProfileDialectImpl) NewSourceProfileConnectionMySQL(params map[string]string, g utils.GetUtilInfoInterface) (SourceProfileConnectionMySQL, error) {
@@ -203,6 +207,27 @@ func (spd *SourceProfileDialectImpl) NewSourceProfileConnectionMySQL(params map[
 	}
 	if mysql.Pwd == "" {
 		mysql.Pwd = g.GetPassword()
+	}
+
+	if sslmode, ok := params["sslmode"]; ok {
+		mysql.Sslmode = sslmode
+	} else {
+		mysql.Sslmode = os.Getenv("MYSQL_SSL_MODE")
+	}
+	if sslrootcert, ok := params["sslrootcert"]; ok {
+		mysql.Sslrootcert = sslrootcert
+	} else {
+		mysql.Sslrootcert = os.Getenv("MYSQL_SSL_ROOT_CERT")
+	}
+	if sslcert, ok := params["sslcert"]; ok {
+		mysql.Sslcert = sslcert
+	} else {
+		mysql.Sslcert = os.Getenv("MYSQL_SSL_CERT")
+	}
+	if sslkey, ok := params["sslkey"]; ok {
+		mysql.Sslkey = sslkey
+	} else {
+		mysql.Sslkey = os.Getenv("MYSQL_SSL_KEY")
 	}
 
 	return mysql, nil
@@ -260,6 +285,10 @@ type SourceProfileConnectionPostgreSQL struct {
 	User            string // Same as PGUSER environment variable
 	Db              string // Same as PGDATABASE environment variable
 	Pwd             string // Same as PGPASSWORD environment variable
+	Sslmode         string
+	Sslrootcert     string
+	Sslcert         string
+	Sslkey          string
 }
 
 func (spd *SourceProfileDialectImpl) NewSourceProfileConnectionPostgreSQL(params map[string]string, g utils.GetUtilInfoInterface) (SourceProfileConnectionPostgreSQL, error) {
@@ -303,6 +332,27 @@ func (spd *SourceProfileDialectImpl) NewSourceProfileConnectionPostgreSQL(params
 	}
 	if pg.Pwd == "" {
 		pg.Pwd = g.GetPassword()
+	}
+
+	if sslmode, ok := params["sslmode"]; ok {
+		pg.Sslmode = sslmode
+	} else {
+		pg.Sslmode = os.Getenv("PGSSLMODE")
+	}
+	if sslrootcert, ok := params["sslrootcert"]; ok {
+		pg.Sslrootcert = sslrootcert
+	} else {
+		pg.Sslrootcert = os.Getenv("PGSSLROOTCERT")
+	}
+	if sslcert, ok := params["sslcert"]; ok {
+		pg.Sslcert = sslcert
+	} else {
+		pg.Sslcert = os.Getenv("PGSSLCERT")
+	}
+	if sslkey, ok := params["sslkey"]; ok {
+		pg.Sslkey = sslkey
+	} else {
+		pg.Sslkey = os.Getenv("PGSSLKEY")
 	}
 
 	return pg, nil
@@ -421,6 +471,10 @@ type SourceProfileConnectionCassandra struct {
 	Pwd             string
 	Keyspace        string 
 	DataCenter      string  // Cassandra 4.x requires data center information for connection
+	Sslmode         string
+	Sslrootcert     string
+	Sslcert         string
+	Sslkey          string
 }
 
 func (spd *SourceProfileDialectImpl) NewSourceProfileConnectionCassandra(params map[string]string, g utils.GetUtilInfoInterface) (SourceProfileConnectionCassandra, error) {
@@ -450,6 +504,27 @@ func (spd *SourceProfileDialectImpl) NewSourceProfileConnectionCassandra(params 
 	}
 	if cs.Pwd == "" {
 		cs.Pwd = g.GetPassword()
+	}
+
+	if sslmode, ok := params["sslmode"]; ok {
+		cs.Sslmode = sslmode
+	} else {
+		cs.Sslmode = os.Getenv("CASSANDRA_SSL_MODE")
+	}
+	if sslrootcert, ok := params["sslrootcert"]; ok {
+		cs.Sslrootcert = sslrootcert
+	} else {
+		cs.Sslrootcert = os.Getenv("CASSANDRA_SSL_ROOT_CERT")
+	}
+	if sslcert, ok := params["sslcert"]; ok {
+		cs.Sslcert = sslcert
+	} else {
+		cs.Sslcert = os.Getenv("CASSANDRA_SSL_CERT")
+	}
+	if sslkey, ok := params["sslkey"]; ok {
+		cs.Sslkey = sslkey
+	} else {
+		cs.Sslkey = os.Getenv("CASSANDRA_SSL_KEY")
 	}
 
 	return cs, nil

--- a/profiles/source_profile_test.go
+++ b/profiles/source_profile_test.go
@@ -1322,3 +1322,55 @@ func TestNewSourceProfileConnectionCloudSQLPostgreSQL_SecretManager_ImplicitLate
 
 	mockClient.AssertExpectations(t)
 }
+
+func TestNewSourceProfileConnectionTLS(t *testing.T) {
+	sourceProfileDialect := SourceProfileDialectImpl{}
+	g := GetUtilInfoMock{}
+	setGetInfoMockValues(&g)
+
+	t.Run("MySQL parsing with TLS params in profile", func(t *testing.T) {
+		params := map[string]string{
+			"host":        "0.0.0.0",
+			"user":        "user",
+			"dbName":      "db",
+			"password":    "pwd",
+			"sslmode":     "verify-full",
+			"sslrootcert": "/path/to/ca.pem",
+			"sslcert":     "/path/to/cert.pem",
+			"sslkey":      "/path/to/key.pem",
+		}
+		res, err := sourceProfileDialect.NewSourceProfileConnectionMySQL(params, &g)
+		assert.Nil(t, err)
+		assert.Equal(t, "verify-full", res.Sslmode)
+		assert.Equal(t, "/path/to/ca.pem", res.Sslrootcert)
+		assert.Equal(t, "/path/to/cert.pem", res.Sslcert)
+		assert.Equal(t, "/path/to/key.pem", res.Sslkey)
+	})
+
+	t.Run("PostgreSQL parsing with TLS env variables", func(t *testing.T) {
+		os.Setenv("PGSSLMODE", "require")
+		os.Setenv("PGSSLROOTCERT", "/env/ca.pem")
+		os.Setenv("PGSSLCERT", "/env/cert.pem")
+		os.Setenv("PGSSLKEY", "/env/key.pem")
+		defer func() {
+			os.Unsetenv("PGSSLMODE")
+			os.Unsetenv("PGSSLROOTCERT")
+			os.Unsetenv("PGSSLCERT")
+			os.Unsetenv("PGSSLKEY")
+		}()
+
+		params := map[string]string{
+			"host":     "0.0.0.0",
+			"user":     "user",
+			"dbName":   "db",
+			"password": "pwd",
+		}
+		res, err := sourceProfileDialect.NewSourceProfileConnectionPostgreSQL(params, &g)
+		assert.Nil(t, err)
+		assert.Equal(t, "require", res.Sslmode)
+		assert.Equal(t, "/env/ca.pem", res.Sslrootcert)
+		assert.Equal(t, "/env/cert.pem", res.Sslcert)
+		assert.Equal(t, "/env/key.pem", res.Sslkey)
+	})
+}
+

--- a/ui/src/app/components/direct-connection/direct-connection.component.html
+++ b/ui/src/app/components/direct-connection/direct-connection.component.html
@@ -71,6 +71,37 @@
         </mat-error>
       </mat-form-field>
       <br />
+      <!-- SSL/TLS Connection Settings -->
+      <div *ngIf="connectForm.value.dbEngine === 'mysql' || connectForm.value.dbEngine === 'postgres' || connectForm.value.dbEngine === 'cassandra'">
+        <h3 class="primary-header">SSL/TLS Settings</h3>
+
+        <mat-form-field class="full-width" appearance="outline">
+          <mat-label>SSL/TLS Mode</mat-label>
+          <mat-select formControlName="sslmode" id="sslmode-input">
+            <mat-option value="">Default / Preferred</mat-option>
+            <mat-option value="disable">Disable</mat-option>
+            <mat-option value="require">Require</mat-option>
+            <mat-option value="verify-ca">Verify CA</mat-option>
+            <mat-option value="verify-full">Verify Full</mat-option>
+          </mat-select>
+        </mat-form-field>
+
+        <mat-form-field class="full-width" appearance="outline">
+          <mat-label>SSL Root CA File Path</mat-label>
+          <input matInput placeholder="/path/to/ca.pem" name="sslrootcert" type="text" formControlName="sslrootcert" id="sslrootcert-input" />
+        </mat-form-field>
+
+        <mat-form-field class="full-width" appearance="outline">
+          <mat-label>SSL Client Certificate File Path</mat-label>
+          <input matInput placeholder="/path/to/client-cert.pem" name="sslcert" type="text" formControlName="sslcert" id="sslcert-input" />
+        </mat-form-field>
+
+        <mat-form-field class="full-width" appearance="outline">
+          <mat-label>SSL Client Private Key File Path</mat-label>
+          <input matInput placeholder="/path/to/client-key.pem" name="sslkey" type="text" formControlName="sslkey" id="sslkey-input" />
+        </mat-form-field>
+      </div>
+      <br />
       <h3 class="primary-header">Spanner Dialect</h3>
       <mat-form-field class="full-width" appearance="outline">
         <mat-label>Spanner dialect</mat-label>

--- a/ui/src/app/components/direct-connection/direct-connection.component.ts
+++ b/ui/src/app/components/direct-connection/direct-connection.component.ts
@@ -28,6 +28,10 @@ export class DirectConnectionComponent implements OnInit {
     dbName: new FormControl('', [Validators.required]),
     dialect: new FormControl('', [Validators.required]),
     dataCenter: new FormControl(''),
+    sslmode: new FormControl(''),
+    sslrootcert: new FormControl(''),
+    sslcert: new FormControl(''),
+    sslkey: new FormControl(''),
   })
 
   dbEngineList = [
@@ -100,7 +104,7 @@ export class DirectConnectionComponent implements OnInit {
 
   testConn() {
     this.clickEvent.openDatabaseLoader('test-connection', this.connectForm.value.dbName!)
-    const { dbEngine, isSharded, hostName, port, userName, password, dbName, dialect, dataCenter } = this.connectForm.value
+    const { dbEngine, isSharded, hostName, port, userName, password, dbName, dialect, dataCenter, sslmode, sslrootcert, sslcert, sslkey } = this.connectForm.value
     localStorage.setItem(PersistedFormValues.DirectConnectForm, JSON.stringify(this.connectForm.value))
     let config: IDbConfig = {
       dbEngine: dbEngine!,
@@ -111,6 +115,10 @@ export class DirectConnectionComponent implements OnInit {
       password: password!,
       dbName: dbName!,
       dataCenter: dataCenter!,
+      sslmode: sslmode!,
+      sslrootcert: sslrootcert!,
+      sslcert: sslcert!,
+      sslkey: sslkey!,
     }
     this.connectRequest =this.fetch.connectTodb(config, dialect!).subscribe({
         next: () => {
@@ -149,7 +157,7 @@ export class DirectConnectionComponent implements OnInit {
         window.scroll(0, 0);
         this.data.resetStore();
         localStorage.clear();
-        const { dbEngine, isSharded, hostName, port, userName, password, dbName, dialect, dataCenter } = this.connectForm.value;
+        const { dbEngine, isSharded, hostName, port, userName, password, dbName, dialect, dataCenter, sslmode, sslrootcert, sslcert, sslkey } = this.connectForm.value;
         localStorage.setItem(PersistedFormValues.DirectConnectForm, JSON.stringify(this.connectForm.value));
         let config: IDbConfig = {
           dbEngine: dbEngine!,
@@ -160,6 +168,10 @@ export class DirectConnectionComponent implements OnInit {
           password: password!,
           dbName: dbName!,
           dataCenter: dataCenter!,
+          sslmode: sslmode!,
+          sslrootcert: sslrootcert!,
+          sslcert: sslcert!,
+          sslkey: sslkey!,
         };
         this.connectRequest = this.fetch.connectTodb(config, dialect!).subscribe({
           next: () => {

--- a/ui/src/app/model/db-config.ts
+++ b/ui/src/app/model/db-config.ts
@@ -8,6 +8,10 @@ export default interface IDbConfig {
   dbName: string
   dataCenter?: string
   shardId?: string
+  sslmode?: string
+  sslrootcert?: string
+  sslcert?: string
+  sslkey?: string
 }
 
 export interface IDbConfigs {

--- a/webv2/session/types.go
+++ b/webv2/session/types.go
@@ -41,6 +41,10 @@ type SourceDBConnDetails struct {
 	DataCenter     string
 	Path           string
 	ConnectionType string
+	Sslmode        string
+	Sslrootcert    string
+	Sslcert        string
+	Sslkey         string
 }
 
 // SessionState stores information for the current migration session.

--- a/webv2/types/types.go
+++ b/webv2/types/types.go
@@ -23,6 +23,10 @@ type DriverConfig struct {
 	DataCenter  string `json:"DataCenter"`
 	Dialect     string `json:"Dialect"`
 	DataShardId string `json:"DataShardId"`
+	Sslmode     string `json:"Sslmode"`
+	Sslrootcert string `json:"Sslrootcert"`
+	Sslcert     string `json:"Sslcert"`
+	Sslkey      string `json:"Sslkey"`
 }
 
 type DriverConfigs struct {

--- a/webv2/web.go
+++ b/webv2/web.go
@@ -22,7 +22,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
-	"github.com/go-sql-driver/mysql"
+
 	"io/fs"
 	"io/ioutil"
 	"log"
@@ -67,24 +67,55 @@ import (
 )
 
 func createDatabaseConnectionString(config types.DriverConfig) (string, error) {
-
 	var dataSourceName string
 	switch config.Driver {
 	case constants.MYSQL:
-		cfg := mysql.NewConfig()
-		cfg.User = config.User
-		cfg.Passwd = config.Password
-		cfg.Net = "tcp"
-		cfg.Addr = fmt.Sprintf("%s:%s", config.Host, config.Port)
-		cfg.DBName = config.Database
-		dataSourceName = cfg.FormatDSN()
-	case constants.SQLSERVER, constants.POSTGRES:
+		sourceProfile := profiles.SourceProfile{
+			Driver: constants.MYSQL,
+			Conn: profiles.SourceProfileConnection{
+				Ty: profiles.SourceProfileConnectionTypeMySQL,
+				Mysql: profiles.SourceProfileConnectionMySQL{
+					Host:        config.Host,
+					Port:        config.Port,
+					User:        config.User,
+					Pwd:         config.Password,
+					Db:          config.Database,
+					Sslmode:     config.Sslmode,
+					Sslrootcert: config.Sslrootcert,
+					Sslcert:     config.Sslcert,
+					Sslkey:      config.Sslkey,
+				},
+			},
+			Ty: profiles.SourceProfileTypeConnection,
+		}
+		dataSourceName = profiles.GetSQLConnectionStr(sourceProfile)
+	case constants.POSTGRES:
+		sourceProfile := profiles.SourceProfile{
+			Driver: constants.POSTGRES,
+			Conn: profiles.SourceProfileConnection{
+				Ty: profiles.SourceProfileConnectionTypePostgreSQL,
+				Pg: profiles.SourceProfileConnectionPostgreSQL{
+					Host:        config.Host,
+					Port:        config.Port,
+					User:        config.User,
+					Pwd:         config.Password,
+					Db:          config.Database,
+					Sslmode:     config.Sslmode,
+					Sslrootcert: config.Sslrootcert,
+					Sslcert:     config.Sslcert,
+					Sslkey:      config.Sslkey,
+				},
+			},
+			Ty: profiles.SourceProfileTypeConnection,
+		}
+		dataSourceName = profiles.GetSQLConnectionStr(sourceProfile)
+	case constants.SQLSERVER:
 		u := url.URL{
 			Scheme:   config.Driver,
 			User:     url.UserPassword(config.User, config.Password),
 			Host:     fmt.Sprintf("%s:%s", config.Host, config.Port),
 			Path:     config.Database,
-			RawQuery: "sslmode=disable", // Add other parameters here
+			RawQuery: "sslmode=disable",
 		}
 		dataSourceName = u.String()
 	case constants.ORACLE:
@@ -142,6 +173,10 @@ func databaseConnection(w http.ResponseWriter, r *http.Request) {
 			User:           config.User,
 			Password:       config.Password,
 			DataCenter:     config.DataCenter,
+			Sslmode:        config.Sslmode,
+			Sslrootcert:    config.Sslrootcert,
+			Sslcert:        config.Sslcert,
+			Sslkey:         config.Sslkey,
 			ConnectionType: helpers.DIRECT_CONNECT_MODE,
 		}
 		w.WriteHeader(http.StatusOK)
@@ -181,6 +216,10 @@ func databaseConnection(w http.ResponseWriter, r *http.Request) {
 		Port:           config.Port,
 		User:           config.User,
 		Password:       config.Password,
+		Sslmode:        config.Sslmode,
+		Sslrootcert:    config.Sslrootcert,
+		Sslcert:        config.Sslcert,
+		Sslkey:         config.Sslkey,
 		ConnectionType: helpers.DIRECT_CONNECT_MODE,
 	}
 	w.WriteHeader(http.StatusOK)
@@ -295,9 +334,17 @@ func setSourceDBDetailsForDirectConnect(w http.ResponseWriter, r *http.Request) 
 	var dataSourceName string
 	switch config.Driver {
 	case constants.POSTGRES:
-		dataSourceName = fmt.Sprintf("host=%s port=%s user=%s password=%s dbname=%s sslmode=disable", config.Host, config.Port, config.User, config.Password, config.Database)
+		dataSourceName, err = createDatabaseConnectionString(config)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
 	case constants.MYSQL:
-		dataSourceName = fmt.Sprintf("%s:%s@tcp(%s:%s)/%s", config.User, config.Password, config.Host, config.Port, config.Database)
+		dataSourceName, err = createDatabaseConnectionString(config)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
 	case constants.SQLSERVER:
 		dataSourceName = fmt.Sprintf(`sqlserver://%s:%s@%s:%s?database=%s`, config.User, config.Password, config.Host, config.Port, config.Database)
 	case constants.ORACLE:
@@ -319,6 +366,10 @@ func setSourceDBDetailsForDirectConnect(w http.ResponseWriter, r *http.Request) 
 			User:           config.User,
 			Password:       config.Password,
 			DataCenter:     config.DataCenter,
+			Sslmode:        config.Sslmode,
+			Sslrootcert:    config.Sslrootcert,
+			Sslcert:        config.Sslcert,
+			Sslkey:         config.Sslkey,
 			ConnectionType: helpers.DIRECT_CONNECT_MODE,
 		}
 		w.WriteHeader(http.StatusOK)
@@ -350,6 +401,10 @@ func setSourceDBDetailsForDirectConnect(w http.ResponseWriter, r *http.Request) 
 		Port:           config.Port,
 		User:           config.User,
 		Password:       config.Password,
+		Sslmode:        config.Sslmode,
+		Sslrootcert:    config.Sslrootcert,
+		Sslcert:        config.Sslcert,
+		Sslkey:         config.Sslkey,
 		ConnectionType: helpers.DIRECT_CONNECT_MODE,
 	}
 	w.WriteHeader(http.StatusOK)
@@ -367,6 +422,10 @@ func validateCassandraConnection(config types.DriverConfig) (cc.KeyspaceMetadata
 				DataCenter: config.DataCenter,
 				User:       config.User,
 				Pwd:        config.Password,
+				Sslmode:    config.Sslmode,
+				Sslrootcert: config.Sslrootcert,
+				Sslcert:    config.Sslcert,
+				Sslkey:     config.Sslkey,
 			},
 		},
 	}
@@ -715,6 +774,18 @@ func getSourceAndTargetProfiles(ctx context.Context, sessionState *session.Sessi
 		sourceProfileString = fmt.Sprintf("\"host=%v\",\"port=%v\",\"user=%v\",\"password=%v\",\"dbName=%v\"",
 			sourceDBConnectionDetails.Host, sourceDBConnectionDetails.Port, sourceDBConnectionDetails.User,
 			sourceDBConnectionDetails.Password, sessionState.DbName)
+	}
+	if sourceDBConnectionDetails.Sslmode != "" {
+		sourceProfileString = fmt.Sprintf("%s,\"sslmode=%s\"", sourceProfileString, sourceDBConnectionDetails.Sslmode)
+	}
+	if sourceDBConnectionDetails.Sslrootcert != "" {
+		sourceProfileString = fmt.Sprintf("%s,\"sslrootcert=%s\"", sourceProfileString, sourceDBConnectionDetails.Sslrootcert)
+	}
+	if sourceDBConnectionDetails.Sslcert != "" {
+		sourceProfileString = fmt.Sprintf("%s,\"sslcert=%s\"", sourceProfileString, sourceDBConnectionDetails.Sslcert)
+	}
+	if sourceDBConnectionDetails.Sslkey != "" {
+		sourceProfileString = fmt.Sprintf("%s,\"sslkey=%s\"", sourceProfileString, sourceDBConnectionDetails.Sslkey)
 	}
 
 	sessionState.SpannerDatabaseName = details.TargetDetails.TargetDB

--- a/webv2/web_test.go
+++ b/webv2/web_test.go
@@ -36,7 +36,7 @@ func TestValidateCassandraConnection(t *testing.T) {
 		mockClient.On("KeyspaceMetadata", "test_keyspace").Return(mockMetadata, nil).Once()
 		mockClient.On("Close").Return().Once()
 
-		ca.GetOrCreateClient = func(contactPoints []string, port int, keyspace, datacenter, user, password string) (cc.CassandraClusterInterface, error) {
+		ca.GetOrCreateClient = func(contactPoints []string, port int, keyspace, datacenter, user, password string, sslmode, sslrootcert, sslcert, sslkey string) (cc.CassandraClusterInterface, error) {
 			return mockClient, nil
 		}
 
@@ -48,7 +48,7 @@ func TestValidateCassandraConnection(t *testing.T) {
 
 	t.Run("Failure", func(t *testing.T) {
 		expectedErr := errors.New("client creation failed")
-		ca.GetOrCreateClient = func(contactPoints []string, port int, keyspace, datacenter, user, password string) (cc.CassandraClusterInterface, error) {
+		ca.GetOrCreateClient = func(contactPoints []string, port int, keyspace, datacenter, user, password string, sslmode, sslrootcert, sslcert, sslkey string) (cc.CassandraClusterInterface, error) {
 			return nil, expectedErr
 		}
 
@@ -83,7 +83,7 @@ func TestDatabaseConnectionCassandra(t *testing.T) {
 		mockClient.On("KeyspaceMetadata", "test_keyspace").Return(mockMetadata, nil).Once()
 		mockClient.On("Close").Return().Once()
 
-		ca.GetOrCreateClient = func(contactPoints []string, port int, keyspace, datacenter, user, password string) (cc.CassandraClusterInterface, error) {
+		ca.GetOrCreateClient = func(contactPoints []string, port int, keyspace, datacenter, user, password string, sslmode, sslrootcert, sslcert, sslkey string) (cc.CassandraClusterInterface, error) {
 			return mockClient, nil
 		}
 
@@ -103,7 +103,7 @@ func TestDatabaseConnectionCassandra(t *testing.T) {
 
 	t.Run("Failure", func(t *testing.T) {
 		expectedErr := errors.New("client creation failed")
-		ca.GetOrCreateClient = func(contactPoints []string, port int, keyspace, datacenter, user, password string) (cc.CassandraClusterInterface, error) {
+		ca.GetOrCreateClient = func(contactPoints []string, port int, keyspace, datacenter, user, password string, sslmode, sslrootcert, sslcert, sslkey string) (cc.CassandraClusterInterface, error) {
 			return nil, expectedErr
 		}
 
@@ -140,7 +140,7 @@ func TestSetSourceDBDetailsForDirectConnectCassandra(t *testing.T) {
 		mockClient.On("KeyspaceMetadata", "test_keyspace").Return(mockMetadata, nil).Once()
 		mockClient.On("Close").Return().Once()
 
-		ca.GetOrCreateClient = func(contactPoints []string, port int, keyspace, datacenter, user, password string) (cc.CassandraClusterInterface, error) {
+		ca.GetOrCreateClient = func(contactPoints []string, port int, keyspace, datacenter, user, password string, sslmode, sslrootcert, sslcert, sslkey string) (cc.CassandraClusterInterface, error) {
 			return mockClient, nil
 		}
 
@@ -160,7 +160,7 @@ func TestSetSourceDBDetailsForDirectConnectCassandra(t *testing.T) {
 
 	t.Run("Failure", func(t *testing.T) {
 		expectedErr := errors.New("client creation failed")
-		ca.GetOrCreateClient = func(contactPoints []string, port int, keyspace, datacenter, user, password string) (cc.CassandraClusterInterface, error) {
+		ca.GetOrCreateClient = func(contactPoints []string, port int, keyspace, datacenter, user, password string, sslmode, sslrootcert, sslcert, sslkey string) (cc.CassandraClusterInterface, error) {
 			return nil, expectedErr
 		}
 
@@ -227,7 +227,7 @@ func TestCreateDatabaseConnectionString(t *testing.T) {
 				Password: "passw\\`~ord",
 				Database: "testdb",
 			},
-			expectedString: "postgres://user:passw%5C%60~ord@localhost:5432/testdb?sslmode=disable",
+			expectedString: "host=localhost port=5432 user=user password=passw\\`~ord dbname=testdb sslmode=disable",
 			expectError:    false,
 		},
 		{


### PR DESCRIPTION
**Summary**
This PR adds secure connection options (TLS and mTLS) for the three target source database systems (MySQL, PostgreSQL, and Cassandra) across both the command-line interface (CLI) and the web-based user interface (UI).

These changes ensure that users can securely connect to their source databases during schema migration by supplying CA certificates, client certificates, and client private keys. SQL Server and Oracle connection logic remain completely unchanged.

**Key Changes**

1. Connection Structs & Command Parsing (profiles)
Extended SourceProfileConnectionMySQL, SourceProfileConnectionPostgreSQL, and SourceProfileConnectionCassandra to support Sslmode, Sslrootcert, Sslcert, and Sslkey fields.
Populated these fields during profile parsing from both direct flags/parameters and standard environment variables (like PGSSLMODE, MYSQL_SSL_MODE, etc.).

2. Secure DSN Construction (profiles)
MySQL: Added registerMySQLTLSConfig helper to dynamically load and register custom tls.Config in memory via the standard go-sql-driver/mysql registry, mapping correct certificate checks for modes like verify-ca and skip-verify.
PostgreSQL: Mapped TLS parameters directly to DSN key-value pairs.

3. Cassandra Client Setup (accessors)
Extended GetOrCreateCassandraClusterClient and mapped the TLS/SSL parameters to standard gocql.SslOptions (mapping CA path, cert path, private key path, and host validation toggles).

4. Web Backend & UI Integration (webv2, ui)
Extended JSON models and structs in the web server backend to parse and store secure parameters from HTTP payloads.
Updated frontend typescript interfaces and Angular HTML forms to conditionally display secure connection inputs (SSL/TLS Settings) only when the user selects MySQL, PostgreSQL, or Cassandra as the database engine.

**Testing**
Unit Tests:
Added TestNewSourceProfileConnectionTLS to verify TLS properties parsing from parameters and env vars.
Updated TestGetSQLConnectionStr to dynamically generate and register a valid self-signed CA certificate in memory to test MySQL TLS/mTLS DSN builders without file dependencies.
Added new Cassandra TLS cases under TestGetOrCreateCassandraClusterClient.
Validation:
Verified all tests in the repository pass with go test ./....