### PR TITLE
Map Postgres IDENTITY columns safely to Spanner

### DIFF
--- a/sources/postgres/infoschema.go
+++ b/sources/postgres/infoschema.go
@@ -244,6 +244,7 @@ func (isi InfoSchemaImpl) GetColumns(conv *internal.Conv, table common.SchemaAnd
                      = (e.object_catalog, e.object_schema, e.object_name, e.object_type, e.collection_type_identifier))
               where table_schema = $1 and table_name = $2 ORDER BY c.ordinal_position;`
 	serialCols := isi.getSerialColumns(conv, table)
+	identityCols := isi.getIdentityColumns(conv, table)
 	cols, err := isi.Db.Query(q, table.Schema, table.Name)
 	if err != nil {
 		return nil, nil, fmt.Errorf("couldn't get schema for table %s.%s: %s", table.Schema, table.Name, err)
@@ -273,7 +274,8 @@ func (isi InfoSchemaImpl) GetColumns(conv *internal.Conv, table common.SchemaAnd
 			}
 		}
 		isSerialColumn := slices.Contains(serialCols, colName)
-		ignored.Default = colDefault.Valid && !isSerialColumn
+		isIdentityColumn := slices.Contains(identityCols, colName)
+		ignored.Default = colDefault.Valid && !isSerialColumn && !isIdentityColumn
 		colId := internal.GenerateColumnId()
 		c := schema.Column{
 			Id:      colId,
@@ -281,12 +283,33 @@ func (isi InfoSchemaImpl) GetColumns(conv *internal.Conv, table common.SchemaAnd
 			Type:    toType(dataType, elementDataType, charMaxLen, numericPrecision, numericScale),
 			NotNull: common.ToNotNull(conv, isNullable),
 			Ignored: ignored,
-			AutoGen: toAutoGen(isSerialColumn),
+			AutoGen: toAutoGen(isSerialColumn || isIdentityColumn),
 		}
 		colDefs[colId] = c
 		colIds = append(colIds, colId)
 	}
 	return colDefs, colIds, nil
+}
+
+func (isi InfoSchemaImpl) getIdentityColumns(conv *internal.Conv, table common.SchemaAndName) []string {
+	identityColsQuery := `SELECT a.attname FROM pg_attribute a
+        WHERE attrelid = $1::regclass AND attnum > 0 AND a.attidentity IN ('a', 'd');`
+	identityColsResult, err := isi.Db.Query(identityColsQuery, table.Schema+"."+table.Name)
+	if err != nil {
+		// Ignore error for backward compatibility: 'attidentity' was introduced in PostgreSQL 10
+		// to support SQL-standard identity columns (GENERATED ALWAYS / BY DEFAULT AS IDENTITY).
+		// In PostgreSQL 9.6 and older, this query fails because the 'attidentity' column does not exist.
+		// Since older versions do not have identity columns (they use SERIAL/sequences instead)
+		return []string{}
+	}
+	defer identityColsResult.Close()
+	identityCols := []string{}
+	var identityColName string
+	for identityColsResult.Next() {
+		identityColsResult.Scan(&identityColName)
+		identityCols = append(identityCols, identityColName)
+	}
+	return identityCols
 }
 
 func (isi InfoSchemaImpl) getSerialColumns(conv *internal.Conv, table common.SchemaAndName) []string {

--- a/sources/postgres/infoschema.go
+++ b/sources/postgres/infoschema.go
@@ -299,7 +299,12 @@ func (isi InfoSchemaImpl) getIdentityColumns(conv *internal.Conv, table common.S
 		// Ignore error for backward compatibility: 'attidentity' was introduced in PostgreSQL 10
 		// to support SQL-standard identity columns (GENERATED ALWAYS / BY DEFAULT AS IDENTITY).
 		// In PostgreSQL 9.6 and older, this query fails because the 'attidentity' column does not exist.
-		// Since older versions do not have identity columns (they use SERIAL/sequences instead)
+		// Since older versions do not have identity columns (they use SERIAL/sequences instead), we ignore it.
+		if strings.Contains(err.Error(), "attidentity") {
+			return []string{}
+		}
+
+		conv.Unexpected(fmt.Sprintf("Couldn't get information about identity columns for table %s.%s: %s", table.Schema, table.Name, err))
 		return []string{}
 	}
 	defer identityColsResult.Close()

--- a/sources/postgres/infoschema_test.go
+++ b/sources/postgres/infoschema_test.go
@@ -243,6 +243,10 @@ func TestProcessSchema(t *testing.T) {
 			cols:  []string{"attname"},
 		},
 		{
+			query: "SELECT a.attname FROM pg_attribute a WHERE attrelid = (.+) AND attnum > 0 AND a.attidentity IN (.+)",
+			cols:  []string{"attname"},
+		},
+		{
 			query: "SELECT (.+) FROM information_schema.COLUMNS (.+)",
 			args:  []driver.Value{"public", "test_ref"},
 			cols:  []string{"column_name", "data_type", "data_type", "is_nullable", "column_default", "character_maximum_length", "numeric_precision", "numeric_scale"},
@@ -535,6 +539,10 @@ func TestConvertSqlRow_MultiCol(t *testing.T) {
 		{
 			query: "SELECT (.+) FROM pg_attribute (.+)",
 			args:  []driver.Value{"public.test"},
+			cols:  []string{"attname"},
+		},
+		{
+			query: "SELECT a.attname FROM pg_attribute a WHERE attrelid = (.+) AND attnum > 0 AND a.attidentity IN (.+)",
 			cols:  []string{"attname"},
 		},
 		{

--- a/sources/postgres/infoschema_test.go
+++ b/sources/postgres/infoschema_test.go
@@ -639,3 +639,23 @@ func newFalsePtr() *bool {
 	temp := false
 	return &temp
 }
+
+func TestGetIdentityColumns(t *testing.T) {
+	ms := []mockSpec{
+		{
+			query: "SELECT (.+) FROM pg_attribute (.+)",
+			args:  []driver.Value{"public.my_table"},
+			cols:  []string{"attname"},
+			rows: [][]driver.Value{
+				{"id"},
+				{"user_id"},
+			},
+		},
+	}
+	db := mkMockDB(t, ms)
+	conv := internal.MakeConv()
+	isi := InfoSchemaImpl{Db: db}
+
+	identityCols := isi.getIdentityColumns(conv, common.SchemaAndName{Schema: "public", Name: "my_table"})
+	assert.Equal(t, []string{"id", "user_id"}, identityCols)
+}

--- a/sources/postgres/pgdump.go
+++ b/sources/postgres/pgdump.go
@@ -921,6 +921,12 @@ func updateCols(ct pg_query.ConstrType, colNames []string, colDef map[string]sch
 			cd.NotNull = true
 		case pg_query.ConstrType_CONSTR_DEFAULT:
 			cd.Ignored.Default = true
+		case pg_query.ConstrType_CONSTR_IDENTITY:
+			cd.AutoGen = ddl.AutoGenCol{
+				Name:           constants.SERIAL,
+				GenerationType: constants.SERIAL,
+			}
+			cd.Ignored.Default = true
 		}
 		colDef[cid] = cd
 	}

--- a/sources/postgres/pgdump_test.go
+++ b/sources/postgres/pgdump_test.go
@@ -67,6 +67,21 @@ func TestProcessPgDump_Serial(t *testing.T) {
 			},
 		},
 		{
+			name: "Identity column",
+			input: "CREATE TABLE public.identity_test (id integer GENERATED ALWAYS AS IDENTITY PRIMARY KEY, col character varying(255));",
+			expectedSchema: map[string]ddl.CreateTable{
+				"identity_test": ddl.CreateTable{
+					Name:   "identity_test",
+					ColIds: []string{"id", "col"},
+					ColDefs: map[string]ddl.ColumnDef{
+						"id": ddl.ColumnDef{Name: "id", T: ddl.Type{Name: ddl.Int64}, NotNull: true, AutoGen: ddl.AutoGenCol{Name: constants.IDENTITY, GenerationType: constants.IDENTITY}},
+						"col": ddl.ColumnDef{Name: "col", T: ddl.Type{Name: ddl.String, Len: 255}},
+					},
+					PrimaryKeys: []ddl.IndexKey{ddl.IndexKey{ColId: "id", Order: 1}},
+				},
+			},
+		},
+		{
 			name: "Bigserial column",
 			input: "CREATE TABLE public.serial_test (id bigserial NOT NULL PRIMARY KEY, col character varying(255));",
 			expectedSchema: map[string]ddl.CreateTable{


### PR DESCRIPTION
Fixes #545474127

Currently, SMT successfully detects legacy PostgreSQL sequences (e.g., SERIAL types) everywhere. However, the dump file parser entirely misses modern SQL-standard IDENTITY configurations (introduced in PostgreSQL 10+). If a user uploads a dump file from a modern database, their auto-increment columns are silently lost.


### Testing details

#### pg_dump
- Generated a real schema dump using PostgreSQL 16 pg_dump with ALWAYS and BY DEFAULT identity columns across public and custom schemas.
- Verified conversion outputs GENERATED BY DEFAULT AS IDENTITY (BIT_REVERSED_POSITIVE) in Spanner DDL instead of degrading to plain INT64.
- Verified legacy SERIAL columns continue to convert identically without regression.
- Live Database Ingestion (PG 16):

#### PostgreSQL < 10 Backward Compatibility (PG 9.6):
Tested against PostgreSQL 9.6 (where attidentity does not exist).
- Confirmed query error is caught cleanly without failing conversion or producing unexpected warnings, maintaining full support for legacy SERIAL sequences.


#### UI / Web Interface:

- Verified backend API endpoints (/connect, /convert/infoschema, /autoGenMap) return AutoGen=Identity for identity columns.
- Verified the UI properly displays the IdentitySkipRange note badge, enables auto-gen configuration controls (Skip Range / Start Counter With), and does not flag false DefaultValue issues for identity columns.